### PR TITLE
Updating tutorials with workshop feedback

### DIFF
--- a/src/simmate/calculators/vasp/inputs/README.md
+++ b/src/simmate/calculators/vasp/inputs/README.md
@@ -194,19 +194,19 @@ Pymatgen stores all of your vasp potcar files inside of a folder called my_psp
 and they save it to the module location. Because of this, I think conda envs
 actually get messed up when you try to initialize multiple enviornments for the
 potcar files. Instead, I think you should either 1) let the user indicate exactly
-where the files are located or 2) have a .simmate/ folder in their home directory.
+where the files are located or 2) have a simmate/ folder in their home directory.
 This makes it so users can see exactly where their files are located. I don't
 think you should mess with the site-packages folder as this could even cause issues
-on shared installs. There should instead be at .simmate configuration folder that
+on shared installs. There should instead be at simmate configuration folder that
 is easily accessible.
 
 Vasp provides their POTCARs in a dist/Potentials folder. Pymatgen takes their
 format and changes it. I don't think this should be done. Instead I want to keep
-their original folder structure and just move it to /.simmate/vasp/Potentials
+their original folder structure and just move it to /simmate/vasp/Potentials
 This saves the user from having to rename anything and also saves us from having
 to code it and confuse the user where it's being stored
 
-Together, the .simmate folder means I can also just copy/paste a configuration
+Together, the simmate folder means I can also just copy/paste a configuration
 folder to a new computer if I'd like.
 
 I need to learn more about other DFT programs but I'm sure there's a generic

--- a/src/simmate/calculators/vasp/inputs/potcar_mappings.py
+++ b/src/simmate/calculators/vasp/inputs/potcar_mappings.py
@@ -5,8 +5,8 @@ from pathlib import Path
 
 # grab the users set directory for all of their VASP POTCAR files
 # TODO - for now, I assume that the directory is located in...
-#   [home_directory] ~/.simmate/vasp/Potentials
-potcar_dir = os.path.join(Path.home(), ".simmate", "vasp", "Potentials")
+#   [home_directory] ~/simmate/vasp/Potentials
+potcar_dir = os.path.join(Path.home(), "simmate", "vasp", "Potentials")
 
 
 # This maps out where functional POTCARs are located. All of these

--- a/src/simmate/calculators/vasp/tasks/base.py
+++ b/src/simmate/calculators/vasp/tasks/base.py
@@ -12,10 +12,10 @@ from simmate.workflow_engine.tasks.supervised_staged_shell_task import (
 
 
 def get_default_parallel_settings():
-    # We load the user's default parallel settings from ~/.simmate/vasp/INCAR_parallel_settings
+    # We load the user's default parallel settings from ~/simmate/vasp/INCAR_parallel_settings
     # If this file doesn't exist, then we just use an empty dictionary
     settings_filename = os.path.join(
-        Path.home(), ".simmate", "vasp", "INCAR_parallel_settings"
+        Path.home(), "simmate", "vasp", "INCAR_parallel_settings"
     )
     if os.path.exists(settings_filename):
         return Incar.from_file(settings_filename)
@@ -60,7 +60,7 @@ class VaspTask(SSSTask):
     # We also load any parallel settings to add on to the base incar. These
     # should not effect the calculation in any way, but they are still selected
     # based on the computer specs and what runs fastest on it. Therefore, these
-    # settings are loaded from ~/.simmate/vasp/INCAR_parallel_settings by default.
+    # settings are loaded from ~/simmate/vasp/INCAR_parallel_settings by default.
     # This can also be overwritten as well.
     incar_parallel_settings = get_default_parallel_settings()
 

--- a/src/simmate/command_line/start_project.py
+++ b/src/simmate/command_line/start_project.py
@@ -30,12 +30,12 @@ def start_project(project_name):
     # grab the full path to the new project for the user to see
     new_project_directory = os.path.join(os.getcwd(), project_name)
 
-    # also navigate to the user's ~/.simmate/applications.yaml file and we
+    # also navigate to the user's ~/simmate/applications.yaml file and we
     # want to add a new line at the end of it (or create the file if it isn't
     # there yet)
     from pathlib import Path
 
-    apps_yaml = os.path.join(Path.home(), ".simmate", "applications.yaml")
+    apps_yaml = os.path.join(Path.home(), "simmate", "applications.yaml")
     new_line = "\nexample_app.apps.ExampleAppConfig"  # \n ensures a new line
 
     # If the file exists, we append this line to the end of the file. Otherwise,

--- a/src/simmate/command_line/start_project.py
+++ b/src/simmate/command_line/start_project.py
@@ -7,7 +7,7 @@ import click
 @click.argument("project_name", type=click.Path(exists=False))
 def start_project(project_name):
     """
-    This creates creates a new folder and fills it with an example project to
+    This creates a new folder and fills it with an example project to
     get you started with custom simmate code.
     """
 

--- a/src/simmate/configuration/blender/setup.py
+++ b/src/simmate/configuration/blender/setup.py
@@ -24,10 +24,10 @@ import yaml
 
 def get_blender_command():
 
-    # First we look in the .simmate configuration directory and check if it
+    # First we look in the simmate configuration directory and check if it
     # has been set there.
-    #   [home_directory] ~/.simmate/blender.yaml
-    blender_filename = os.path.join(Path.home(), ".simmate", "blender.yaml")
+    #   [home_directory] ~/simmate/blender.yaml
+    blender_filename = os.path.join(Path.home(), "simmate", "blender.yaml")
     if os.path.exists(blender_filename):
         with open(blender_filename) as file:
             blender_command = yaml.full_load(file)["COMMAND"]
@@ -52,7 +52,7 @@ def get_blender_command():
 def find_blender_installation():
     """
     Finds the full path to the Blender installation so that we can call blender
-    from the command-line. This also adds it's location to the .simmate
+    from the command-line. This also adds it's location to the simmate
     configuration folder so that we don't need to search for it every time.
     """
 
@@ -127,11 +127,11 @@ def find_blender_installation():
 
     # We should now have our blender_command set from above. So that we don't need
     # to search for the Blender installation every time we call a visualization
-    # function, we want to save the path to a configuration file in /.simmate
+    # function, we want to save the path to a configuration file in /simmate
 
     # We store the command inside the config directory which is located at...
-    #   [home_directory] ~/.simmate/blender.yaml
-    blender_filename = os.path.join(Path.home(), ".simmate", "blender.yaml")
+    #   [home_directory] ~/simmate/blender.yaml
+    blender_filename = os.path.join(Path.home(), "simmate", "blender.yaml")
     with open(blender_filename, "w") as file:
         file.write(f"COMMAND: {blender_command}")
 

--- a/src/simmate/configuration/dask/__init__.py
+++ b/src/simmate/configuration/dask/__init__.py
@@ -8,6 +8,6 @@ import os
 # in the init.
 os.environ.setdefault(
     "DASK_CONFIG",
-    os.path.join(os.path.expanduser("~"), ".simmate", "dask_cluster.yaml"),
+    os.path.join(os.path.expanduser("~"), "simmate", "dask_cluster.yaml"),
 )
 # TODO: I need to update this to allow for other directories

--- a/src/simmate/configuration/django/settings.py
+++ b/src/simmate/configuration/django/settings.py
@@ -28,11 +28,11 @@ from simmate.utilities import get_directory
 # SET MAIN DIRECTORIES
 
 # We check for extra django apps in the user's home directory and in a "hidden"
-# folder named ".simmate/extra_applications".
+# folder named "simmate/extra_applications".
 # For windows, this would be something like...
-#   C:\Users\exampleuser\.simmate\extra_applications
+#   C:\Users\exampleuser\simmate\extra_applications
 # Note, we use get_directory in order to create that folder if it does not exist.
-SIMMATE_DIRECTORY = get_directory(os.path.join(Path.home(), ".simmate"))
+SIMMATE_DIRECTORY = get_directory(os.path.join(Path.home(), "simmate"))
 
 # This directory is where simmate.website is located and helps us indicate
 # where things like our templates or static files are located. We find this

--- a/src/simmate/configuration/example_project/README.md
+++ b/src/simmate/configuration/example_project/README.md
@@ -3,7 +3,7 @@
 
 
 
-We also added the example_app to your ~/.simmate/applications.yaml file.
+We also added the example_app to your ~/simmate/applications.yaml file.
 If you ever want to remove or rename your apps, make sure you update this file too.
 Also, make sure you install this project to your python path with...
 pip install -e {project_name}

--- a/src/simmate/configuration/prefect/projects.py
+++ b/src/simmate/configuration/prefect/projects.py
@@ -53,7 +53,7 @@ def build():
             set_schedule_active=False,
         )
     # TODO: will I need to store the project or workflow IDs? Maybe inside
-    # the /.simmate/prefect folder? Or maybe even the /.prefect folder?
+    # the /simmate/prefect folder? Or maybe even the /.prefect folder?
     # I could also return a list of what's been done.
 
 

--- a/src/simmate/configuration/prefect/setup_resources.py
+++ b/src/simmate/configuration/prefect/setup_resources.py
@@ -37,7 +37,7 @@ HEADER_ART = r"""
 
 # Load our default cluster type, agent name, and agent labels
 def load_agent_settings():
-    SIMMATE_DIRECTORY = os.path.join(Path.home(), ".simmate")
+    SIMMATE_DIRECTORY = os.path.join(Path.home(), "simmate")
     AGENT_YAML = os.path.join(SIMMATE_DIRECTORY, "prefect_agent.yaml")
     if os.path.exists(AGENT_YAML):
         with open(AGENT_YAML) as file:

--- a/src/simmate/workflow_engine/tasks/workflow_task.py
+++ b/src/simmate/workflow_engine/tasks/workflow_task.py
@@ -17,10 +17,10 @@ from simmate.workflow_engine.workflow import Workflow
 # def get_default_executor_type():
 #     # rather than always specifying the executor type whenever this class is used,
 #     # it's much more convenient to set the default value here based on a config
-#     # file. We check for this in the file ".simmate/extra_applications".
+#     # file. We check for this in the file "simmate/extra_applications".
 #     # For windows, this would be something like...
-#     #   C:\Users\exampleuser\.simmate\executor.yaml
-#     SIMMATE_DIRECTORY = os.path.join(Path.home(), ".simmate")
+#     #   C:\Users\exampleuser\simmate\executor.yaml
+#     SIMMATE_DIRECTORY = os.path.join(Path.home(), "simmate")
 #     EXECUTOR_YAML = os.path.join(SIMMATE_DIRECTORY, "executor.yaml")
 #     if os.path.exists(EXECUTOR_YAML):
 #         with open(EXECUTOR_YAML) as file:

--- a/tutorials/01_Installation.md
+++ b/tutorials/01_Installation.md
@@ -13,6 +13,7 @@ In this tutorial, you will learn how to install Simmate with Anaconda. Beginners
     - [Extra Resources](#extra-resources)
 
 <br/><br/>
+
 # The quick tutorial
 
 > :warning: In this tutorial and others, beginners should skip the **quick tutorial** section and jump straight to the **full tutorial**. The critical steps in each are exactly the same, but the full tutorial includes extra exploration of the software and how to use it. So be sure to read the full tutorials if you don't have coding experience!
@@ -27,6 +28,7 @@ conda activate my_env
 3. Run the `simmate` command to make sure it's installed correctly
 
 <br/><br/>
+
 # The full tutorial
 
 <br/>
@@ -110,9 +112,19 @@ You'll see `(base)` at the start of the line. This is our anaconda enviornment t
 
 Now, try typing in the command `cd Desktop` and then hit enter. This will open up your Desktop folder. Then enter the command `ls`, which will list all files and folders on your Desktop. 
 
+```
+# run these two commands
+cd Desktop
+ls
+```
+
 For other simple commands, you can take a look at [this cheat sheet](https://www.git-tower.com/blog/command-line-cheat-sheet/) or take [a full tutorial](https://www.codecademy.com/learn/learn-the-command-line). Memorizing commands will come slowly over time, so keep this cheat-sheet handy. We highly recommend that you spend 30 minutes going through these links once you finish this tutorial.
 
 Obviously, the tricky part with the command-line is knowing what to type. Fortunately, however, most programs have a single command that forms the base of more complex commands. For anaconda, the command is `conda`. If you aren't sure what it does or how to use it, you just add `--help` to it. Type in the command `conda --help` and you'll see an output like this:
+
+```
+conda --help
+```
 
 ```
 usage: conda [-h] [-V] command ...
@@ -150,7 +162,7 @@ You'll see the start of your command line switch from `(base)` to `(my_env)` if 
 conda install -c conda-forge -n my_env simmate
 ```
 
-This may take a few minutes to run and install. But once it's done, you've now successfully installed Simmate! If you ran into any errors with this very last command, please let our team know immediately by [posting a new issue here](https://github.com/jacksund/simmate/issues/new).
+This may take a few minutes to run and install. But once it's done, you've now successfully installed Simmate! If you ran into any errors with this very last command, please let our team know immediately by [posting a new issue here](https://github.com/jacksund/simmate/issues/).
 
 As an extra, let's use Anaconda to install [Spyder](https://www.spyder-ide.org/). Spyder is what we will use to write python in later tutorials. But now that we have Anaconda set up, installing new programs can be done in just one line:
 ```
@@ -164,12 +176,19 @@ conda install -c conda-forge -n my_env spyder
 Just like we used `conda --help` above, we can also ask for help with Simmate. Start with running the command `simmate --help` and you should see the following output:
 
 ```
+simmate --help
+```
+
+```
 Usage: simmate [OPTIONS] COMMAND [ARGS]...
 
   This is the base command that all others stem from.
 
-  If you are a beginner for the command line, take a look at our tutorial:
-  << TODO: insert link >>
+  If you are a beginner to the command line, be sure to start with our
+  tutorials: https://github.com/jacksund/simmate/tree/main/tutorials
+
+  Below you will see a list of sub-commands to try. For example, you can run
+  `simmate database --help` to learn more about it.
 
 Options:
   --help  Show this message and exit.
@@ -184,7 +203,7 @@ Commands:
 
 You can see there are many other commands like `simmate database` and `simmate workflows` that we will explore in other tutorials. 
 
-But we're now ready to start using the code!
+But we're now ready to start using the code! Spend some time with the extra resources (next section) and then continue on to [the next tutorial](https://github.com/jacksund/simmate/blob/main/tutorials/02_%20Run_a_workflow.md).
 
 <br/>
 

--- a/tutorials/02_ Run_a_workflow.md
+++ b/tutorials/02_ Run_a_workflow.md
@@ -394,7 +394,7 @@ For example, UNC's longleaf cluster uses [SLURM](https://slurm.schedmd.com/docum
 #SBATCH --job-name=my_example_job
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=1
+#SBATCH --cpus-per-task=4
 #SBATCH --mem=4GB
 #SBATCH --time=01:00:00
 #SBATCH --partition=general
@@ -402,13 +402,31 @@ For example, UNC's longleaf cluster uses [SLURM](https://slurm.schedmd.com/docum
 #SBATCH --mail-type=ALL 
 #SBATCH --mail-user=my_username@live.unc.edu
 
-simmate workflows run energy_mit POSCAR
+simmate workflows run energy_mit POSCAR -c "mpirun -n 4 vasp_std > vasp.out"
 ```
+
+Each of these `SBATCH` parameters set how we would like to sumbit a job and how many resources we expect to use. These are explained in [SLURM's documnetation for sbatch](https://slurm.schedmd.com/sbatch.html), but you may need help from your IT team to update them. But to break down these example parameters...
+
+- `job-name`: the name that identifies your job. It will be visible when you check the status of your job
+- `nodes`: the number of server nodes (or CPUs) that you request. Typically leave this at 1.
+- `ntasks`: the number tasks that you'll be running. We run one workflow at a time here, so we use 1.
+- `cpus-per-task`: the number of CPU tasks required for each run. We run our workflow using 4 cores (`mpirun -n 4`) so we need to request 4 cores for it here
+- `mem`: the memory requested for this job. If it is exceeded, the job will be terminated.
+- `time`: the maximum time requested for this job. If it is exceeded, the job will be terminated.
+- `partition`: the group of nodes that we request resources on. You can often remove this line and use the cluster's default.
+- `output`: the name of the file to write the job output (including errors)
+- `mail-type` + `mail-user`: will send an email alerts when a jobs starts/stops/fails/etc.
 
 Make sure you have VASP and your correct conda enviornment loaded. Then submit your job with:
 
 ```
 sbatch submit.sh
+```
+
+You can then monitor your jobs progress with:
+
+```
+squeue -u my_username
 ```
 
 You've now submitted a Simmate workflow to a remote cluster :partying_face: :partying_face: :partying_face: !!! 

--- a/tutorials/02_ Run_a_workflow.md
+++ b/tutorials/02_ Run_a_workflow.md
@@ -5,6 +5,7 @@ In this tutorial, you will use the command line to view all available workflows 
 1. [The quick tutorial](#the-quick-tutorial)
 2. [The full tutorial](#the-full-tutorial)
     - [The 4 stages of a workflow](#the-4-stages-of-a-workflow)
+    - [Configuring Potentials (for VASP users)](#configuring-potentials-for-vasp-users)
     - [Setting up our database](#setting-up-our-database)
     - [Making a structure file for practice](#making-a-structure-file-for-practice)
     - [Viewing available workflows](#viewing-available-workflows)
@@ -16,9 +17,9 @@ In this tutorial, you will use the command line to view all available workflows 
 
 # The quick tutorial
 
-> :warning: we assume you have VASP installed and that the `vasp_std` command is in the available path. In the future, we hope to update this tutorial with a workflow that doesn't require VASP. Until then, we apologize for the inconvenience. :cry:
+> :warning: for the quick tutorial, we assume you have VASP installed and that the `vasp_std` command is in the available path. In the future, we hope to update this tutorial with a workflow that doesn't require VASP or remote Linux cluster. Until then, we apologize for the inconvenience. :cry:
 
-1. Before running a workflow, we must initialize our Simmate database with `simmate database reset`. Your database will be built at `~/.simmate/database.sqlite3`.
+1. Before running a workflow, we must initialize our Simmate database with `simmate database reset`. Your database will be built at `~/simmate/database.sqlite3`.
 2. To practice calculating, make structure file for tablesalt (NaCl). Name it `POSCAR`, where the contents are...
 ```
 Na1 Cl1
@@ -34,9 +35,27 @@ direct
 ```
 3. View a list of all workflows available with `simmate workflows list-all`
 4. View the settings used for the `energy_mit` workflow with `simmate workflows show-config energy_mit`
-5. Copy and paste VASP POTCAR files to the folder `~/.simmate/vasp/Potentials`. This folder will have the potentials that came with VASP -- and with their original folder+file names. For example there would be an LDA folder that contains subfolders potpaw_LDA, potpaw_LDA.52, potpaw_LDA.54, and so on. Make sure these folders aren't compressed (no *.zip files).
+5. Copy and paste VASP POTCAR files to the folder `~/simmate/vasp/Potentials`. Be sure to unpack the `tar.gz` files. This folder will have the potentials that came with VASP -- and with their original folder+file names:
+```
+# Located at /home/my_username (~)
+simmate/
+└── vasp
+    └── Potentials
+        ├── LDA
+        │   ├── potpaw_LDA
+        │   ├── potpaw_LDA.52
+        │   ├── potpaw_LDA.54
+        │   └── potUSPP_LDA
+        ├── PBE
+        │   ├── potpaw_PBE
+        │   ├── potpaw_PBE.52
+        │   └── potpaw_PBE.54
+        └── PW91
+            ├── potpaw_GGA
+            └── potUSPP_GGA
+```
 6. View the input files with `simmate workflows setup-only energy_mit POSCAR`
-7. Run a workflow with `simmate workflows run energy_mit POSCAR` (run = configure + schedule + execute + save)
+7. Run a workflow with `simmate workflows run energy_mit POSCAR` (run = configure + schedule + execute + save). This command should be submitted via a SLURM/PBS job script on HPC clusters.
 8. For now, you can manually go through the files to see the results. We will cover how to access your database in a later tutorial (05).
 
 <br/><br/>
@@ -67,21 +86,29 @@ For now, we just want to run a workflow using Simmate's default settings. Withou
 
 Before we can actually run this workflow, we must:
 
-1. set up our database so results can be saved
-2. select a structure for our calculation
+1. tell Simmate where our VASP files are
+2. set up our database so results can be saved
+3. select a structure for our calculation
+
+The next three sections will address each of these requirements.
 
 <br/> <!-- add empty line -->
 
 ## Setting up our database
 
-We often want to run the same calculation on many materials, so Simmate pre-builds database tables for us to fill. This just means we make tables (like those used in Excel), where we have all the column headers ready to go. For example, you can imagine that a table of structures would have columns for formula, density, and number of sites, among other things. Simmate builds these tables for you and automatically fills all the columns with data after a calculation finishes. We will explore what these tables look like in tutorial 5, but for now, we want Simmate to create them. All we have to do is run the command `simmate database reset` to do this. When you call this command, Simmate will print out a bunch of information -- this can be ignored for now. It's just making all of your tables.
+We often want to run the same calculation on many materials, so Simmate pre-builds database tables for us to fill. This just means we make tables (like those used in Excel), where we have all the column headers ready to go. For example, you can imagine that a table of structures would have columns for formula, density, and number of sites, among other things. Simmate builds these tables for you and automatically fills all the columns with data after a calculation finishes. We will explore what these tables look like in tutorial 5, but for now, we want Simmate to create them. All we have to do is run the following command 
+
+```
+simmate database reset
+```
+
+When you call this command, Simmate will print out a bunch of information -- this can be ignored for now. It's just making all of your tables.
 
 > :warning: Every time you run the command `simmate database reset`, the database is deleted and a new one is written with empty tables.  If you want to keep your previous runs, you should save a copy of your database. If you share a home directory with other users, check with them before running this command.
 
-So where is the database stored? After running `simmate database reset`, you'll find it in a file named `~/.simmate/database.sqlite3`. However, finding this may be tricky for beginners *(Note, if you struggle here, you can simply move on to the next section. Don't worry.)*. Here are some tips to help you:
-1. remember from tutorial 1 that `~` is short for our home directory -- typically something like `/home/jacksund/` or `C:\Users\jacksund`. 
-2. the period in `.simmate` means that the simmate folder is hidden. It won't show up in your file viewer unless you have "show hidden files" turned on in your File Explorer (on Windows, check "Hidden Items" under the "View" tab). 
-3. we want to get in the habit of viewing file extensions, so make sure you also have "show file name extensions" enabled. Then you'll see a file named `database.sqlite3` instead of just `database`.
+So where is the database stored? After running `simmate database reset`, you'll find it in a file named `~/simmate/database.sqlite3`. To find this file:
+1. remember from tutorial 1 that `~` is short for our home directory -- typically something like `/home/jacksund/` or `C:\Users\jacksund`.
+2. have "show hidden files" turned on in your File Explorer (on Windows, check "show file name extensions" under the "View" tab). Then you'll see a file named `database.sqlite3` instead of just `database`.
 
 You won't be able to double-click this file. Just like how you need Excel to open and read Excel (.xlsx) files, we need a separate program to read database (.sqlite3) files. We'll use Simmate to do this later on.
 
@@ -93,7 +120,15 @@ But just after that one command, our database is setup any ready to use! We can 
 
 Before we run a workflow, we need a crystal structure to run it on. There are many ways to get a crystal structure -- such as downloading one online or using a program to create one from scratch. Here, in order to learn about structure files, we are going to make one from scratch without any program.
 
-First, make a new text file on your Desktop named `POSCAR.txt`. Note, we can see the `.txt` ending because we enabled "show file name extensions" above. Once you have this file, copy/paste this text into it:
+First, make a new text file on your Desktop named `POSCAR.txt`. You can use which text editor you prefer (Notepad, Sublime, etc.). You can also create the file using the command like with:
+
+```
+nano POSCAR.txt
+```
+
+Note, we can see the `.txt` ending because we enabled "show file name extensions" above.
+
+Once you have this file, copy/paste this text into it:
 
 ```
 Na1 Cl1
@@ -139,7 +174,13 @@ loop_
   Cl  Cl1  1  0.50000000  0.50000000  0.50000000  1
 ```
 
-Nearly all files that you will interact with are text files -- just in different formats. That's where file extensions come in. They indicate what format we are using. Files named `something.cif` just tell programs we have a text file written if the CIF structure format. VASP uses the name POSCAR (without any file extension) to show its format. So rename your file from `POSCAR.txt` to `POSCAR`, and now all programs (VESTA, OVITO, and others) will know what to do with your structure. In Windows, you will often receive a warning about changing the file extension.  Ignore the warning and change the extension.
+Nearly all files that you will interact with are text files -- just in different formats. That's where file extensions come in. They indicate what format we are using. Files named `something.cif` just tell programs we have a text file written if the CIF structure format. VASP uses the name POSCAR (without any file extension) to show its format. So rename your file from `POSCAR.txt` to `POSCAR`, and now all programs (VESTA, OVITO, and others) will know what to do with your structure. In Windows, you will often receive a warning about changing the file extension. Ignore the warning and change the extension.
+
+If you're using the command-line to create/edit this file, you can use the copy (`cp`) command to make the `POSCAR` file:
+
+```
+cp POSCAR.txt POSCAR
+```
 
 > :bulb: **fun fact**: a Microsoft Word document is just a folder of text files. The .docx file ending tells Word that we have the folder in their desired format. Try renaming a word file from `my_file.docx` to `my_file.zip` and open it up to explore. Nearly all programs do something like this!
 
@@ -147,11 +188,63 @@ We now have our structure ready to go! Let's get back to running a workflow.
 
 <br/> <!-- add empty line -->
 
+## Configuring Potentials (for VASP users)
+
+> :warning: once Simmate switches from VASP to a free DFT alternative, this section of the tutorial will be removed. 
+
+VASP is a very popular software for running DFT calculations, but our team can't install it for you because VASP is commercially licensed (i.e. you need to [purchase it from their team](https://www.vasp.at/), which we are not affiliated with). Simmate is working to switch to another DFT software -- specifically one that is free/open-source, that can be preinstalled for you, and that you can use on Windows+Mac+Linux. Until Simmate reaches this milestone, you'll have to use VASP. We apologize for the inconvenience.
+
+While VASP can only be installed on Linux, we will still practice configuring VASP with Simmate on our local computer. To do this, you only need the Potentials that are distrubited with the VASP installation files. You can either...
+
+1. Grab these from the VASP installation files. You can find them at `vasp/5.x.x/dist/Potentials`. Be sure to unpack the `tar.gz` files.
+2. Ask a team member or your IT team for a copy of these files.
+
+Once you have the potentials, paste them into a folder named `~/simmate/vasp/Potentials`. Note, this is same directory that your database is in (`~/simmate`) where you need to make a new folder named `vasp`. This folder will have the potentials that came with VASP -- and with their original folder+file names. Once you have all of this done, you're folder should look like this:
+
+```
+# Located at /home/my_username (~)
+simmate/
+├── database.sqlite3
+└── vasp
+    └── Potentials
+        ├── LDA
+        │   ├── potpaw_LDA
+        │   ├── potpaw_LDA.52
+        │   ├── potpaw_LDA.54
+        │   └── potUSPP_LDA
+        ├── PBE
+        │   ├── potpaw_PBE
+        │   ├── potpaw_PBE.52
+        │   └── potpaw_PBE.54
+        └── PW91
+            ├── potpaw_GGA
+            └── potUSPP_GGA
+```
+
+If you made this folder incorrectly, commands that you use later will fail with an error like...
+
+```python
+FileNotFoundError: [Errno 2] No such file or directory: '/home/jacksund/simmate/vasp/Potentials/PBE/potpaw_PBE.54/Na/POTCAR'
+```
+
+If you see this error, double-check your folder setup.
+
+> :warning: our team only has access to VASP v5.4.4, so if your folder structure differs for newer versions of VASP, please let our know by [opening an issue](https://github.com/jacksund/simmate/issues).
+
+
+<br/> <!-- add empty line -->
+
 ## Viewing available workflows
 
 At the most basic level, you'll want to use Simmate to calculate a material's energy, structure, or properties. For each type of task, we have prebuilt workflows. All of these are accessible through the `simmate workflows` command.
 
-Let's start by seeing what is available by running `simmate workflows list-all`. You should see something like:
+Let's start by seeing what is available by running:
+
+```
+simmate workflows list-all
+```
+
+The output will be similar to...
 
 ```
 Gathering all available workflows...
@@ -176,15 +269,29 @@ In this tutorial, we will be using `energy_mit` which runs a simple static energ
 
 Take a look back at the 4 key steps of a workflow above (`configure`, `schedule`, `execute`, and `save`). Here, we will inspect the `configure` step.
 
-To view a workflow's configuration before using it, we type the command `simmate workflows show-config`. Try this out by running `simmate workflows show-config relaxation_quality00`. VASP users will recognize that this specifies the contents of a VASP INCAR file.  The `relaxation_quality00` is the most basic workflow configuration because the INCAR will not depend on the structure or composition of your crystal.
+To view a workflow's configuration before using it, we type the command `simmate workflows show-config`. Try this out by running:
 
-Next, look at a more advanced calculation. Run the command `simmate workflows show-config energy_mit`. Here, you'll see that some INCAR settings rely on composition and that we have a list of error handlers to help ensure that the calculation finishes successfully.
+```
+simmate workflows show-config relaxation_quality00
+```
 
-> :warning: For this next step, you need to have VASP POTCARs available, which our team is not allowed to distribute. You can either (1) configure them now, or (2) skip to the next section (we will address the installation of VASP in the "Switching to a remote cluster" section below. 
+VASP users will recognize that this specifies the contents of a VASP INCAR file.  The `relaxation_quality00` is the most basic workflow configuration because the INCAR will not depend on the structure or composition of your crystal.
 
-> (from the section below) To "configure" POTCARs with Simmate, we need to only copy/paste them to the folder ~/.simmate/vasp/Potentials. This is where Simmate will look for them. This folder will have the potentials that came with VASP -- and with their original folder+file names. For example there would be an LDA folder that contains subfolders potpaw_LDA, potpaw_LDA.52, potpaw_LDA.54, and so on. Make sure these folders aren't compressed (so not *.zip files).
+Next, look at a more advanced calculation. Run the command:
 
-Now, let's go one step further and feed a specific structure (the POSCAR we just made) into a specific workflow (energy_MIT). To do this, make sure our terminal has the same folder open as where our file is! For example, if your POSCAR is on your Desktop while your terminal is in your home directory, you can type `cd Desktop` to change your active folder to your Desktop. Then run the command `simmate workflows setup-only energy_mit POSCAR`. You'll see a new folder created named `MIT_Static_Energy_inputs`. When you open it, you'll see all the files that Simmate made for VASP to use. This is useful when you're an advanced user who wants to alter these files before running VASP manually -- this could happen when you want to test new workflows or unique systems.
+```
+simmate workflows show-config energy_mit
+```
+
+Here, you'll see that some INCAR settings rely on composition and that we have a list of error handlers to help ensure that the calculation finishes successfully.
+
+Now, let's go one step further and provide a specific structure (the POSCAR we just made) into a specific workflow (energy_mit). To do this, make sure our terminal has the same folder open as where our file is! For example, if your POSCAR is on your Desktop while your terminal is in your home directory, you can type `cd Desktop` to change your active folder to your Desktop. Then run the command:
+
+```
+simmate workflows setup-only energy_mit POSCAR
+```
+
+You'll see a new folder created named `MIT_Static_Energy_inputs`. When you open it, you'll see all the files that Simmate made for VASP to use. This is useful when you're an advanced user who wants to alter these files before running VASP manually -- this could happen when you want to test new workflows or unique systems.
 
 For absolute beginners, you don't immediately need to understand these files, but they will eventually be important for understanding the scientific limitations of your results or for running your own custom calculations. Whether you use [VASP](https://www.vasp.at/wiki/index.php/Category:Tutorials), [ABINIT](https://docs.abinit.org/tutorial/), or another program, be sure to go through their tutorials, rather than always depending on Simmate to run the program for you.  Until you reach that point, we'll have Simmate do it all for us!
 
@@ -192,20 +299,31 @@ For absolute beginners, you don't immediately need to understand these files, bu
 
 ## Finally running our workflow!
 
+> :warning: Unless you have VASP installed on your local computer, these next commands will fail. **That is okay!** Let's go ahead and try running these commands anyways. It will be helpful to see how Simmate workflows fail when VASP is not configured properly. If you don't have VASP installed, you'll see an error stating that the `vasp_std` command isn't known (such as `vasp_std: not found` on Linux). We'll switch to a remote computer with VASP installed in the next section.
+
 The default Simmate settings will run everything immediately and locally on your desktop. When running the workflow, it will create a new folder, write the inputs in it, run the calculation, and save the results to your database.
 
-> :warning: Unless you have both (1) your POTCARs configured and (2) VASP installed on your local computer, these next commands will fail. **That is okay!** Let's go ahead and try running these commands anyways. It will be helpful to see how Simmate workflows fail when VASP is not configured properly. If you didn't configure your POTCARs, you'll see an error that states `FileNotFoundError: [Errno 2] No such file or directory: '/example/path/to/POTCAR'`. If you don't have VASP installed, you'll see an error stating that the `vasp_std` command isn't known (such as `vasp: not found` on Linux). The next section will help you address these errors.
+The command to do this with our POSCAR and energy_mit workflow is: 
 
-The command to do this with our POSCAR and energy_mit workflow is `simmate workflows run energy_mit POSCAR`. By default, Simmate uses the command `vasp_std > vasp.out` and creates a new `simmate-task` folder with a unique identifier (ex: `simmate-task-j8djk3mn8`).
+```
+simmate workflows run energy_mit POSCAR
+```
 
-Alternatively, we can change our folder name as well as the command used to run VASP. For example, we can update our command to this:
+By default, Simmate uses the command `vasp_std > vasp.out` and creates a new `simmate-task` folder with a unique identifier (ex: `simmate-task-j8djk3mn8`).
+
+What if we wanted to change this command or the directory it's ran in? First, check the help output for the command:
+```
+simmate workflows run --help
+```
+
+Using this help info, we can change our folder name (`--directory`, `-d`) as well as the command used to run VASP (`--command`, `-c`). For example, we can update our command to this:
+
 ```
 simmate workflows run energy_mit POSCAR -c "mpirun -n 4 vasp_std > vasp.out" -d my_custom_folder
 ```
 
-To see all the options for running workflows, type `simmate workflows run --help`.  
 
-If any errors come up, please let our team know by [posting a question](https://github.com/jacksund/simmate/discussions/new?category=q-a). If not, congrats :partying_face: :partying_face: :partying_face: !!! You now know how to run workflows with a single command and understand what Simmate is doing behind the scenes.
+If any errors come up, please let our team know by [posting a question](https://github.com/jacksund/simmate/discussions/categories/q-a). If not, congrats :partying_face: :partying_face: :partying_face: !!! You now know how to run workflows with a single command and understand what Simmate is doing behind the scenes.
 
 <br/> <!-- add empty line -->
 
@@ -213,41 +331,60 @@ If any errors come up, please let our team know by [posting a question](https://
 
 > :warning: This section can be extremely difficult for beginners. If you can, try to sit down with an experienced user or someone from your IT department as you work through it. Don't get discouraged if this section takes your more than an hour -- it's a lot to learn!
 
-Thus far, you've been running Simmate on your local desktop or laptop, but we saw in the two previous sections, that we actually need VASP (which needs to be on Linux) for Simmate's workflows to run. VASP is a very popular software for running DFT calculations, but our team can't install it for you because VASP is commercially licensed (i.e. you need to [buy it from their team](https://www.vasp.at/), which we are not affiliated with). Simmate is working to switch to another DFT software -- specifically one that is free/open-source, that can be preinstalled for you, and that you can use on Windows+Mac+Linux. Until Simmate reaches this milestone, you'll have to use VASP. We apologize for the inconvenience.
+Thus far, you've been running Simmate on your local desktop or laptop, but we saw in the previous section, that we actually need VASP (which needs to be on Linux) for Simmate's workflows to run. 99% of the time, you'll be using a University or Federal supercomputer (aka "high performance computing (HPC) clusters"), which will have VASP already installed.
 
-Once you have a VASP license, the next step is installing it somewhere -- likely a University or Federal supercomputer. Many of these supercomputers (aka "high performance computing (HPC) clusters") will have VASP already installed. Contact your IT team and they can get you started. For example, the University of North Carolina (where Simmate is developed) has the [LongLeaf](https://its.unc.edu/research-computing/longleaf-cluster/) cluster and has guides on making an account. 
+For teams that are actively using Simmate, we have a guides on submitting to that particular cluster. [Check to see if your university or federal cluster is listed](#). Use these guides as you work through the rest of this section. If your cluster/university is not listed, contact your IT team for help in completing this tutorial.
 
-Signing into a remote cluster is typically done through SSH. For example, to sign in to the LongLeaf cluster, you would run the following command in your local terminal (on windows, use your Command-prompt -- not the Anaconda Powershell Prompt):
+For workflows to run correctly, the following requirements need to be met:
+
+1. a VASP license for your team ([purchased on their site](https://www.vasp.at/))
+2. a remote cluster that you have a profile with (e.g. UNC's [LongLeaf](https://its.unc.edu/research-computing/longleaf-cluster/))
+3. VASP installed on the remote cluster
+4. Anaconda installed on the remote cluster
+5. Simmate installed on the remote cluster
+6. VASP Potentials in `~/simmate/vasp/Potentials` on the remote cluster
+
+The remainder of this tutorial gives example commands to use. Replace these commands and scripts with the ones in your cluster's guide.
+
+If you've never signed into a remote cluster before, we will do this by using SSH (Secure Shell). For example, to sign in to University of North Carolina's LongLeaf cluster, you would run the following command in your local terminal (on windows, use your Command-prompt -- not the Anaconda Powershell Prompt):
 
 ```
 ssh my_username@longleaf.unc.edu
 ```
 
-After entering your password, you are now using a terminal on the remote supercomputer! Try running the command `pwd` ("print working directory") to show that your terminal is indeed running commands on the remote cluster, not your desktop.
+After entering your password, you are now using a terminal on the remote supercomputer. Try running the command `pwd` ("print working directory") to show that your terminal is indeed running commands on the remote cluster, not your desktop:
 
-To load VASP, you typically need to run the command `module load vasp` or even `module load vasp/5.4.4`. Now try the command `vasp_std`. If everything was installed correctly, you won't get the `vasp_std: command not found` anymore!  If that didn't work, check which modules you have available by typing `module avail`.
+```
+pwd
+```
 
-If you see `(base)` at the start of your command-line, Anaconda is already installed! If not, ask your IT team how they want you install it (typically it's by using [miniconda](https://docs.conda.io/en/latest/miniconda.html) which is just anaconda without the graphical user interface). With Anaconda set up, you can create your environment and install Simmate just like we did in tutorial 01:
+To load VASP into your environment, you typically need to run the command:
+
+```
+module load vasp
+vasp_std
+```
+
+If the vasp_std command worked correctly, you will see (their command doesn't print help information like `simmate` or `conda`):
+
+```
+Error reading item 'VCAIMAGES' from file INCAR.
+```
+
+Next we need to ensure Simmate is installed. If you see `(base)` at the start of your command-line, Anaconda is already installed! If not, ask your IT team how they want you install it (typically it's by using [miniconda](https://docs.conda.io/en/latest/miniconda.html) which is just anaconda without the graphical user interface). With Anaconda set up, you can create your environment and install Simmate just like we did in tutorial 01:
 
 ```
 conda create -n my_env -c conda-forge python=3.8 simmate
 conda activate my_env
 
-# also, don't forget to initialize your database on this new installation
+# Initialize your database on this new installation.
+# If you share a username with others, check your guide before running this.
 simmate database reset
 ```
 
-We now have Simmate and VASP installed. Next, we need to tell Simmate where the VASP POTCARs are located. If you're unsure where these files are, you can ask your IT team where VASP's installation files are. These installation files will include the POTCARs in the Potentials folder.
+Lastly, copy your Potentials into `~/simmate/vasp/Potentials` and also copy the `POSCAR` file above on your cluster. It can be diffult in the command line to move files around or even transfer them back and forth from your local computer to the supercomputer. It's much easier with a program like [FileZilla](https://filezilla-project.org/), [MobaXTerm](https://mobaxterm.mobatek.net/), or another file transfer window. We recommend FileZilla, but it's entirely optional and up to you.
 
-To "configure" POTCARs with Simmate, copy/paste the Potentials folder into the ~/.simmate/vasp/Potentials. This is where Simmate will look for them. This folder will have the potentials that came with VASP -- and with their original folder+file names. For example there would be an LDA folder that contains subfolders potpaw_LDA, potpaw_LDA.52, potpaw_LDA.54, and so on. Make sure these folders aren't compressed (so not *.zip files).
-
-> :bulb: It can be diffult in the command line to move files around or even transfer them back and forth from your local computer to the supercomputer. It's much easier with a program like [FileZilla](https://filezilla-project.org/), [MobaXTerm](https://mobaxterm.mobatek.net/), or another file transfer window. We recommend FileZilla, but it's entirely optional and up to you.
-
-You can check that POTCARs are configured properly with the command `simmate workflows setup-only energy_mit POSCAR` (using the POSCAR from earlier in this tutorial).
-
-Next, let's submit a Simmate workflow on our cluster! In the previous section, we called `simmate workflows run ...` directly in our terminal, but this should **NEVER** be done on a supercomputer. Instead we should submit the workflow to the cluster's job queue. Typically, supercomputers use SLURM or PBS to submit jobs. 
-
-> :warning: The examples below use SLURM. PBS has very similar commands and setup to what's shown, but talk with your IT team to get started.
+Finally, let's submit a Simmate workflow on our cluster! In the previous section, we called `simmate workflows run ...` directly in our terminal, but this should **NEVER** be done on a supercomputer. Instead we should submit the workflow to the cluster's job queue. Typically, supercomputers use SLURM or PBS to submit jobs.
 
 For example, UNC's longleaf cluster uses [SLURM](https://slurm.schedmd.com/documentation.html). To submit, we would make a file named `submit.sh` with the contents:
 
@@ -268,8 +405,14 @@ For example, UNC's longleaf cluster uses [SLURM](https://slurm.schedmd.com/docum
 simmate workflows run energy_mit POSCAR
 ```
 
-Make sure you have VASP and your correct conda enviornment loaded. Then submit your job with `sbatch submit.sh`.
+Make sure you have VASP and your correct conda enviornment loaded. Then submit your job with:
+
+```
+sbatch submit.sh
+```
 
 You've now submitted a Simmate workflow to a remote cluster :partying_face: :partying_face: :partying_face: !!! 
 
 Be sure to go back through this tutorial a few times before moving on. Submitting remote jobs can be tedious but it's important to understand. Advanced features of Simmate will let you skip a lot of this work down the road, but that won't happen until tutorial 07.
+
+When you're ready, you can advance to [the next tutorial](https://github.com/jacksund/simmate/blob/main/tutorials/03_Analyze_and_modify_structures.md), which be back on your local computer.

--- a/tutorials/02_ Run_a_workflow.md
+++ b/tutorials/02_ Run_a_workflow.md
@@ -415,4 +415,4 @@ You've now submitted a Simmate workflow to a remote cluster :partying_face: :par
 
 Be sure to go back through this tutorial a few times before moving on. Submitting remote jobs can be tedious but it's important to understand. Advanced features of Simmate will let you skip a lot of this work down the road, but that won't happen until tutorial 07.
 
-When you're ready, you can advance to [the next tutorial](https://github.com/jacksund/simmate/blob/main/tutorials/03_Analyze_and_modify_structures.md), which be back on your local computer.
+When you're ready, you can advance to [the next tutorial](https://github.com/jacksund/simmate/blob/main/tutorials/03_Analyze_and_modify_structures.md), which can be completed on your local computer.

--- a/tutorials/03_Analyze_and_modify_structures.md
+++ b/tutorials/03_Analyze_and_modify_structures.md
@@ -98,7 +98,7 @@ There are many more features available! If you can't find what you're looking fo
 
 ## An introduction to Spyder
 
-Prebuilt workflows can only take you so far when carrying out materials research. At some point, you'll want to make new crystal structures, modify them in some way, and perform a novel analysis on it. To do all of this, we turn away from the command-line and now start using python. If you are a brand new to coding and python, we will introduce the bare-minimum of python needed to start using simmate's toolkit in this tutorial, but we highly recommend spending 2-3 days on learning all the python fundamentals. [Codecademy's python lessons](https://www.codecademy.com/learn/learn-python-3) are a great way to learn without installing anything extra.
+Prebuilt workflows can only take you so far when carrying out materials research. At some point, you'll want to make new crystal structures, modify them in some way, and perform a novel analysis. To do all of this, we turn away from the command-line and now start using python. If you are a brand new to coding and python, we will introduce the bare-minimum of python needed to start using simmate's toolkit in this tutorial, but we highly recommend spending 2-3 days on learning all the python fundamentals. [Codecademy's python lessons](https://www.codecademy.com/learn/learn-python-3) are a great way to learn without installing anything extra.
 
 Ready or not, let's learn how to use Simmate's python code. Recall from tutorial 1: Anaconda gave us a bunch of programs on their home screen, such as Orange3, Jupyter Notebook, Spyder, and others. These programs are for you to write your own python code. Just like how there is Microsoft Word, Google Docs, and LibreOffice for writing papers, all of these programs are different ways to write Python. Our team uses Spyder, so we highly recommend users pick Spyder too.
 
@@ -121,14 +121,47 @@ In real life, we might say that McDonald's, Burger King, and Wendy's are example
 
 In materials science, the class we use most is crystal structure. In Simmate, we call this class `Structure`. A crystal structure is _**always**_ made up of a lattice and a list of atomic sites. Fortunately, this is exactly what we have in our `POSCAR` file from tutorial 2, so let's use Simmate to create an instance of the `Structure` class using our POSCAR file.
 
-Start by entering `from simmate.toolkit import Structure` into the python console and hit enter. This line says we want to use the `Structure` class from Simmate's code. The `Structure` class is now loaded into memory and is waiting for you to do something with it.
+Start by entering this line into the python console and hit enter:
+
+```python
+from simmate.toolkit import Structure
+```
+
+This line says we want to use the `Structure` class from Simmate's code. The `Structure` class is now loaded into memory and is waiting for you to do something with it.
 
 Next, make sure you have the correct working directory (just like we did with the command-line). Spyder lists this in the top right -- and you can hit the folder icon to change it. We want to be in the same folder as our POSCAR file.
 
-Next, run the line `nacl_structure = Structure.from_file("POSCAR")` in your python terminal. Here, we told python that we have a `Structure` and the information for it is located in the `POSCAR` file. This could be in many other formats, such as a CIF file. But we now have a `Structure` object and it is named `nacl_structure`. Alternatively, we could have created this structure manually:
+Next, run this line in your python terminal:
 
 ```python
-# note we can name the object whatever we want. I chose 's' here.
+nacl_structure = Structure.from_file("POSCAR")
+```
+
+Here, we told python that we have a `Structure` and the information for it is located in the `POSCAR` file. This could be in many other formats, such as a CIF file. But we now have a `Structure` object and it is named `nacl_structure`. To make sure it loaded correctly, run this line:
+
+```python
+nacl_structure
+```
+
+It should print out...
+
+```
+Structure Summary
+Lattice
+    abc : 4.02463542 4.02463542 4.02463542
+ angles : 59.99999999999999 59.99999999999999 59.99999999999999
+ volume : 46.09614820053437
+      A : 3.4854365146906536 0.0 2.0123177100000005
+      B : 1.1618121715635514 3.2861010599106226 2.0123177100000005
+      C : 0.0 0.0 4.02463542
+PeriodicSite: Na (0.0000, 0.0000, 0.0000) [0.0000, 0.0000, 0.0000]
+PeriodicSite: Cl (2.3236, 1.6431, 4.0246) [0.5000, 0.5000, 0.5000]
+```
+
+This is the same information from our POSCAR! Alternatively, we could have created this structure manually:
+
+```python
+# note we can name the object whatever we want. We use 's' here.
 s = Structure(
     lattice=[
         [3.48543651, 0.0, 2.01231771],
@@ -151,22 +184,38 @@ Whatever your method for creating a structure, we now have our `Structure` objec
 
 We make classes because they allow us to automate common calculations. For example, all structures have a `density`, which is easily calculated once you know the lattice and atomic sites. You can access this and other properties through our structure object. Try typing `nacl_structure.density` in the python terminal and hit enter. It should tell you the density!
 
-Now what about other properties for the lattice, like volume, angles, and vectors? For the sake of organization, the `Structure` class has a sub-class called `lattice`, and within `lattice` we find properties like `volume`. Try out these in your python terminal (only run one line at a time):
+Now what about other properties for the lattice, like volume, angles, and vectors? For the sake of organization, the `Structure` class has an associated class called `Lattice`, and within the `lattice` object we find properties like `volume`. Try out these in your python terminal (only run one line at a time):
 
-```
+```python
 nacl_structure.lattice.volume
 nacl_structure.lattice.matrix
 nacl_structure.lattice.beta
 ```
 
-If you don't like to type long lines, there is a shortcut.  We create a `Lattice` object (here, we call it as `nacl_lat`, but you can pick a different name) and then call its properties:
+Your outputs will be...
 
 ```
+# EXPECTED OUTPUTS
+
+46.09614820053437
+
+array([[3.48543651, 0.        , 2.01231771],
+       [1.16181217, 3.28610106, 2.01231771],
+       [0.        , 0.        , 4.02463542]])
+
+59.99999999999999
+```
+
+If you don't like to type long lines, there is a shortcut.  We save the `Lattice` object (here, we call it as `nacl_lat`, but you can pick a different name) to a new variable name and then call its properties:
+
+```python
 nacl_lat = nacl_structure.lattice
 nacl_lat.volume
 nacl_lat.matrix
 nacl_lat.beta
 ```
+
+Note, outputs will be the same as above.
 
 We can apply the same idea to other `Structure` sub-classes, such as `Composition`. This allows us to see properties related to composition:
 ```
@@ -175,11 +224,36 @@ nacl_compo.reduced_formula
 nacl_compo.elements
 ```
 
+This will give outputs of...
+
+```
+# EXPECTED OUTPUTS
+
+Comp: Na1 Cl1
+
+'NaCl'
+
+[Element Na, Element Cl]  # <-- these are Element objects!
+```
+
+As you create new python objects and name them different things, you'll need help keep track of them. Fortunately, Spyder's variable explorer (a tab in top right window) let's us track them! Try double-clicking some of your variables and explore what Spyder can do:
+
+<!-- This is an image of the Spyder IDE variable explorer -->
+<p align="center" style="margin-bottom:40px;">
+<img src="https://docs.spyder-ide.org/current/_images/variable-explorer-execution.gif"  height=440 style="max-height: 440px;">
+</p>
+
 <br/> <!-- add empty line -->
 
 ## Methods of a `Structure` object
 
-In addition to `properties`, an object can also have `methods`. Typically, a method will perform a calculation; it may also save the results of that calculation. For example, you might want to convert a conventional unit cell into a primitive unit cell.  You can do this with `nacl_structure.get_primitive_structure()`. Try this in your terminal. You'll see it prints out a new structure. For this method, we save it by defining a new `Structure` object:
+In addition to `properties`, an object can also have `methods`. Typically, a method will perform a calculation; it may also save the results of that calculation. For example, you might want to convert a conventional unit cell into a primitive unit cell.  You can do this with `nacl_structure.get_primitive_structure()`. Try this in your python console:
+
+```python
+nacl_structure.get_primitive_structure()
+```
+
+You'll see it prints out a new structure. We had the primitive structure already, so it should be identical to our output from before. For this method, we save it as a new `Structure` object by assigning it to the name `nacl_prim`:
 
 ```python
 nacl_prim = nacl_structure.get_primitive_structure()
@@ -195,6 +269,7 @@ nacl_structure.get_primitive_structure(tolerance=0.1)
 the calculation will allow atoms that are nearly in their 'symmetrically correct' positions (within 0.1 Å) to be identiified as symmetrical. Note, we didn't have to set a tolerance before because there are default values being used. Some methods don't have defaults. For example, the `make_supercell` method require you to specify a supercell size. 
 
 There are many other methods available for structures too:
+
 ```python
 nacl_structure.add_oxidation_state_by_guess()
 nacl_structure.make_supercell([2,2,2])
@@ -217,6 +292,7 @@ To give you a sneak-peak of some advanced classes and functionality, we outline 
 
 Simmate's toolkit is (at the moment) most useful for structure creation. This includes creating structures from random symmetry, prototype structures, and more.
 We only need to give these "creator" classes a composition object:
+
 ```python
 from simmate.toolkit import Composition
 from simmate.toolkit.creators.structure.all import RandomSymStructure
@@ -228,7 +304,7 @@ structure1 = creator.create_structure(spacegroup=166)
 structure2 = creator.create_structure(spacegroup=225)
 ```
 
-Matminer is particularly useful for analyzing "features" of a structure and making machine-learning inputs. One common analysis gives the "fingerprint" of the structure, which helps characterize bonding in the crystal. The most basic fingerprint is the radial distribution function (rdf) -- it shows the distribution of all atoms from one another. We take any structure object and can feed it to a matminer `Featurizer` object:
+Matminer is particularly useful for analyzing "features" of a structure and making machine-learning inputs. One common analysis gives the "fingerprint" of the structure, which helps characterize bonding in the crystal. The most basic fingerprint is the radial distribution function (rdf) -- it shows the distance of all atoms from one another. We take any structure object and can feed it to a matminer `Featurizer` object:
 
 ```python
 from matminer.featurizers.structure.rdf import RadialDistributionFunction
@@ -239,30 +315,38 @@ rdf1 = rdf_analyzer.featurize(structure1)
 rdf2 = rdf_analyzer.featurize(structure2)
 ```
 
-We can plot an RDF using python too. Matminer doesn't have a convenient way to plot this for us yet (with Simmate there would be a `show_plot` method), so we can use this opportunity to learn how to plot things ourselves:
+We can plot an RDF using python too. Matminer doesn't have a convenient way to plot this for us yet (with Simmate there would be a `show_plot()` method), so we can use this opportunity to learn how to plot things ourselves:
 
 ```python
-from matplotlib.pyplot import plot
+import matplotlib.pyplot as plt
 
 # The x-axis goes from 0.1 to 20 in steps 0.1 (in Angstroms).
 # Matminer doesn't give us a list of these values but
 # we can make it using this line.
 rdf_x = [n/10 + 0.1 for n in range(0, 200)]
 
+# Make a simple line plot with lists of (x,y) values
+plt.plot(rdf_x, rdf1)
+
 # Show the plot without any fancy formatting or labels.
-plot(rdf_x, rdf1)
+plt.show()
 ```
 
 Pymatgen is currently the largest package and has the most toolkit-like features. As an example, it's common to compare two structures and see if are symmetrically equivalent (within a given tolerance). You give it two structures and it will return True or False on whether they are matching:
+
 ```python
 from pymatgen.analysis.structure_matcher import StructureMatcher
 
 matcher = StructureMatcher()
 
-is_matching = matcher.fit(structure1, structure2)
+# Now compare our two random structures!
+# This should give False. Check in your Spyder variable explorer.
+is_matching = matcher.fit(structure1, structure2)  
 ```
 
-If you're trying to follow a paper and analyze a structure, odds are that someone made a class/function for that analysis! Be sure to search around the documentation for it (next tutorial teaches you how to do this) or just [post a question](https://github.com/jacksund/simmate/discussions/new?category=q-a) and we'll point you in the right direction.
+If you're trying to follow a paper and analyze a structure, odds are that someone made a class/function for that analysis! Be sure to search around the documentation for it (next tutorial teaches you how to do this) or just [post a question](https://github.com/jacksund/simmate/discussions/categories/q-a) and we'll point you in the right direction.
+
+Take some time to master Python and Spyder with the resources below, and when you're ready, advance to [the next tutorial](https://github.com/jacksund/simmate/blob/main/tutorials/04_Explore_the_code.md).
 
 <br/> <!-- add empty line -->
 

--- a/tutorials/03_Analyze_and_modify_structures.md
+++ b/tutorials/03_Analyze_and_modify_structures.md
@@ -65,24 +65,41 @@ What about advanced features? Simmate is slowly adding these to our toolkit modu
 ```python
 # Simmate is in the process of adding new features. One example
 # creating a random structure from a spacegroup and composition
+
 from simmate.toolkit import Composition
 from simmate.toolkit.creators.structure.all import RandomSymStructure
+
 composition = Composition("Ca2N")
 creator = RandomSymStructure(composition)
-structure = creator.create_structure(spacegroup=166)
+
+structure1 = creator.create_structure(spacegroup=166)
+structure2 = creator.create_structure(spacegroup=225)
+
+# ----------------------------------------------------------------------
 
 # Matminer is handy for analyzing structures and making
 # machine-learning inputs. One common analysis is the generating
 # a RDF fingerprint to help analyze bonding and compare structures
+
 from matminer.featurizers.structure.rdf import RadialDistributionFunction
-rdf_analyzer = RadialDistributionFunction()
-rdf = rdf_analyzer.featurize(structure)
+
+rdf_analyzer = RadialDistributionFunction(bin_size=0.1)
+
+rdf1 = rdf_analyzer.featurize(structure1)
+rdf2 = rdf_analyzer.featurize(structure2)
+
+# ----------------------------------------------------------------------
 
 # Pymatgen currently has the most functionality. One common
 # function is checking if two structures are symmetrically
 # equivalent (under some tolerance).
+
 from pymatgen.analysis.structure_matcher import StructureMatcher
+
 matcher = StructureMatcher()
+
+# Now compare our two random structures!
+# This should give False. Check in your Spyder variable explorer.
 is_matching = matcher.fit(structure1, structure2)
 ```
 
@@ -177,6 +194,25 @@ s = Structure(
 ```
 
 Whatever your method for creating a structure, we now have our `Structure` object and we can use its properties (and methods) to simplify our calculations.
+
+For example, we can use it to run a workflow. We did this with the command-line in the last tutorial but can accomplish the same thing with python:
+
+```
+# Using the command-line (from our previous tutorial)
+simmate workflows run energy_mit POSCAR
+```
+
+```python
+# Using Python (in Spyder)
+
+# This code does the exact same thing as the command above
+
+from simmate.toolkit import Structure
+from simmate.workflows.all import relaxation_mit
+
+nacl_structure = Structure.from_file("POSCAR")
+result = relaxation_mit.run(structure=nacl_structure)
+```
 
 <br/> <!-- add empty line -->
 

--- a/tutorials/04_Explore_the_code.md
+++ b/tutorials/04_Explore_the_code.md
@@ -26,17 +26,37 @@ For advanced users, we have README.rst files in each of our python modules -- so
 
 ## Getting help through Spyder
 
-Where we left off in Tutorial 3, we saw how to list all available properties and methods on an object. We did this by typing the object name plus a period (ex: `nacl_structure.`) and then hitting `tab`.
+Where we left off in Tutorial 3, we saw how to list all available properties and methods on an object. We did this by typing the object name plus a period (ex: `nacl_structure.`) and then hitting `tab`:
+
+```python
+from simmate.toolkit import Structure
+
+nacl_structure = Structure.from_file("POSCAR")
+
+nacl_structure.  # hit "tab" on your keyboard
+```
 
 > :warning: for this next part, pymatgen's documentation isn't always complete or beginner-friendly. This is why you won't see much. We're working on this at Simmate, so we hope this improves in the future. For now, don't expect too much guidance from the `Structure` class.
 
-Now let's take a step back and get a full guide on a these methods and properties. We'll start with the `Structure` class that we previously imported using `from simmate.toolkit import Structure`. (If you restarted your python terminal, run this import again.) Next, try typing the line `Structure?` and hit enter. What pops up is the documentation. Just like how we were using `--help` in the command-line for tutorial 1, we can use `?` in python to get help with python classes and objects!
+Now let's take a step back and get a full guide on a these methods and properties. We'll start with the `Structure` class that we previously imported using `from simmate.toolkit import Structure` and try the line `Structure?`:
+
+```python 
+from simmate.toolkit import Structure
+
+Structure?  # <-- the ? here will bring up documentation help
+```
+
+What pops up is the documentation. Just like how we were using `--help` in the command-line for tutorial 1, we can use `?` in python to get help with python classes and objects!
 
 We can also format this nicely using Spyder. In bottom part of Spyder's top-right window, select the `help` tab. And in the search bar (with "object") right next to it, type in `Structure`. You'll see the help information pop up again, but now it's nicely formatted for us.
 
-Let's try this with our NaCl structure from before. To review, we loaded the structure with `NaCl_structure = Structure.from_file("POSCAR")`. Now try typing `NaCl_structure.get_primitive_structure` in our help window. We can now see a description of what this does and the arguments/options ("Args") that it accepts. 
+Let's try this with our NaCl structure from before. Now try typing `nacl_structure.get_primitive_structure` in our help window. We can now see a description of what this does and the arguments/options ("Args") that it accepts.
 
-You can also get this help information by typing `NaCl_structure.get_primitive_structure` in the python terminal and then using the `crtl+I` shortcut.
+You can also get this help information by typing `nacl_structure.get_primitive_structure` in the python terminal and then using the `ctrl+I` shortcut.
+
+```python
+nacl_structure.get_primitive_structure  # hit "ctrl+I" BEFORE hitting enter on this line
+```
 
 <br/>
 
@@ -53,10 +73,10 @@ So whenever you see an `import` line, it's just telling you where the actual cod
 To prove it, let's go through these steps:
 
 1. run `import simmate` in your python terminal
-2. get the help docs for `simmate` in the Spyder help window
+2. get the help docs for `simmate` in the Spyder help window using ctrl+I
 3. on Simmate's github homepage, go the [src/simmate folder](https://github.com/jacksund/simmate/tree/main/src/simmate) (src = source code)
 4. You should see the same thing! Also you'll see the `toolkit` folder that we were using before.
-5. Navigate through the folders. `simmate` --> `toolkit` --> `core` --> `lattice.py`. 
+5. Navigate through the folders. `simmate` --> `toolkit` --> `base_data_types` --> `lattice.py`. 
 6. You see a Lattice class where all of it's methods and properties are defined.
 
 Each of these folders and files are referred to as python "modules" -- it's just python terminology.
@@ -69,11 +89,19 @@ Now that we know Simmate is just a bunch of classes organized into folders, let'
 
 We'll start with the `toolkit` module ([here](https://github.com/jacksund/simmate/tree/main/src/simmate/toolkit), but try finding it yourself without the link). When you open it up, you'll see an overview/guide. You can also access this module using `from simmate import toolkit` and getting help directly in spyder.
 
+```
+from simmate import toolkit
+
+toolkit  # use ctrl+I before hitting enter
+```
+
 A good folder to look through is the `simmate.toolkit.creators` module, which provides many ways to create lattices, sites, and structures (e.g. randomly, random symmetry, etc.) and also incorporates third-party codes.
 
 > :warning: because simmate is still at the early stages, some folders will be more complete than others. Keep this in mind while exploring. If you aren't seeing a guide or documentation, we probably haven't finished that module yet.
 
-Take some time to look through the features and functions. Always feel free to ask if a feature exists, and if not, request one too. Post those questions in our [discussions page](https://github.com/jacksund/simmate/discussions/new?category=q-a).
+Take some time to look through the features and functions. Always feel free to ask if a feature exists, and if not, request one too. Post those questions in our [discussions page](https://github.com/jacksund/simmate/discussions/categories/q-a).
+
+Once you're done exploring, you can move on to [the next tutorial](https://github.com/jacksund/simmate/blob/main/tutorials/05_Search_the_database.md).
 
 <br/>
 

--- a/tutorials/05_Search_the_database.md
+++ b/tutorials/05_Search_the_database.md
@@ -53,7 +53,7 @@ dataframe = first_150_rows.to_dataframe()
 
 # The full tutorial
 
-> :bulb: This entire tutorial should be ran on your local computer because we will be using Spyder. To use results from your remote calculations, you can copy/paste your database file from your remote computer to where our local database one should be (~/.simmate/database.sqlite3). Note, copy/pasting will no longer be necessary when we switch to a cloud database in the next tutorial.
+> :bulb: This entire tutorial should be ran on your local computer because we will be using Spyder. To use results from your remote calculations, you can copy/paste your database file from your remote computer to where our local database one should be (~/simmate/database.sqlite3). Note, copy/pasting will no longer be necessary when we switch to a cloud database in the next tutorial.
 
 <br/>
 

--- a/tutorials/05_Search_the_database.md
+++ b/tutorials/05_Search_the_database.md
@@ -137,7 +137,14 @@ from simmate.workflows.all import energy_mit
 result_table = energy_mit.result_table
 ```
 
-To see all of the data this table stores, we can use it's `result_table.show_columns()` method. Here, we'll see a bunch of columns printed for us...
+To see all of the data this table stores, we can use it's `show_columns()` method. Here, we'll see a bunch of columns printed for us...
+
+```python
+result_table.show_columns()
+```
+
+... which will output ...
+
 ```
 - id
 - structure_string
@@ -183,6 +190,7 @@ To see all of the data this table stores, we can use it's `result_table.show_col
 These are a lot of columns... and you may not need all of them. But Simmate still builds all of these for you right away because they don't take up very much storage space.
 
 Next we'd want to see the table with all of its data. To access the table rows, we use the `objects` attribute, and then to get this into a table, we convert to a "dataframe". A dataframe is a filtered portion of a database table -- and because we didn't filter any of our results yet, our dataframe is just the whole table. 
+
 ```python
 data = result_table.objects.to_dataframe()
 ```
@@ -277,4 +285,6 @@ structures = JarvisStructure.objects.filter(
 ).all()
 ```
 
-There are many ways to search through your tables, and we only covered the basics here. Advanced users will benefit from knowing that we use [Django's query api](https://docs.djangoproject.com/en/3.2/topics/db/queries/) under the hood. It can take a long time to master, so we only recommend going through [Django's full tutorial](https://docs.djangoproject.com/en/4.0/) if you plan on joining our team or are a fully computational student. Beginners can just ask for help. Figuring out the correct filter can take new users hours while it will only take our team a minute or two. Save your time and [post questions here](https://github.com/jacksund/simmate/discussions/new?category=q-a).
+There are many ways to search through your tables, and we only covered the basics here. Advanced users will benefit from knowing that we use [Django's query api](https://docs.djangoproject.com/en/3.2/topics/db/queries/) under the hood. It can take a long time to master, so we only recommend going through [Django's full tutorial](https://docs.djangoproject.com/en/4.0/) if you plan on joining our team or are a fully computational student. Beginners can just ask for help. Figuring out the correct filter can take new users hours while it will only take our team a minute or two. Save your time and [post questions here](https://github.com/jacksund/simmate/discussions/categories/q-a).
+
+Up next, we can start sharing results with others! Continue to [the next tutorial](https://github.com/jacksund/simmate/blob/main/tutorials/05_Search_the_database.md) when you're ready.

--- a/tutorials/06_Use_a_cloud_database.md
+++ b/tutorials/06_Use_a_cloud_database.md
@@ -19,7 +19,7 @@ In this tutorial, you will learn how to switch from saving results locally to sa
 ```
 conda install -n my_env -c conda-forge psycopg2
 ```
-4. Add the file `~/.simmate/database.yaml` with your connection details that match [django format](https://docs.djangoproject.com/en/dev/ref/settings/#databases). As an example, this `database.yaml` file gives a `default` database to use:
+4. Add the file `~/simmate/database.yaml` with your connection details that match [django format](https://docs.djangoproject.com/en/dev/ref/settings/#databases). As an example, this `database.yaml` file gives a `default` database to use:
 ```
 default:
   ENGINE: django.db.backends.postgresql_psycopg2
@@ -65,13 +65,13 @@ PostgreSQL is free and open-source, so you can avoid costs and set it up manuall
 
 If you decide to use Postgres, you'll also need to install the extra package `psycopg2`, which let's Django talk with Postgres. To install this, run the command `conda install -n my_env -c conda-forge psycopg2`.
 
-Once you have your database set-up, add the connection parameters to `~/.simmate/database.yaml` (see the quick tutorial above for an example) and then run `simmate database reset` to build all of your tables. You can then share your `database.yaml` (or alternatively, make new user profiles and share those connection details) with your team members.
+Once you have your database set-up, add the connection parameters to `~/simmate/database.yaml` (see the quick tutorial above for an example) and then run `simmate database reset` to build all of your tables. You can then share your `database.yaml` (or alternatively, make new user profiles and share those connection details) with your team members.
 
 <br/>
 
 ## Connecting to your cloud database
 
-This will be the easiest thing we've done yet! Once you have the connection parameters for your cloud database, simply create the file `~/.simmate/database.yaml` and add the connection parameters that your point-person provided. As an example, this `database.yaml` file gives a `default` database to use:
+This will be the easiest thing we've done yet! Once you have the connection parameters for your cloud database, simply create the file `~/simmate/database.yaml` and add the connection parameters that your point-person provided. As an example, this `database.yaml` file gives a `default` database to use:
 ```
 default:
   ENGINE: django.db.backends.postgresql_psycopg2

--- a/tutorials/Guides_for_HPC_clusters/WarWulf.md
+++ b/tutorials/Guides_for_HPC_clusters/WarWulf.md
@@ -1,0 +1,105 @@
+
+# WarWulf
+
+WarWulf is the Warren Lab's Beowulf cluster.
+
+# Guide
+
+This guide should be used alongside tutorial 02 when switching to a remote cluster ([here](https://github.com/jacksund/simmate/blob/main/tutorials/02_%20Run_a_workflow.md#switching-to-a-remote-cluster)).
+
+## The Simmate checklist
+
+From the posted requirements:
+
+1. a VASP license for your team **(COMPLETED)**
+2. a remote cluster that you have a profile with 
+3. VASP installed on the remote cluster **(COMPLETED)**
+4. Anaconda installed on the remote cluster **(COMPLETED)**
+5. Simmate installed on the remote cluster
+6. VASP Potentials in `~/simmate/vasp/Potentials` on the remote cluster **(COMPLETED)**
+
+For the uncompleted requirements:
+
+2. everyone shares the profile "WarrenLab". Ask Scott for the password (scw@email.unc.edu)
+5. make your personal environment named `yourname_env` (e.g. `jacks_env`)
+
+## Example commands and scripts
+
+Substitute these commands with the ones you see in the main tutorial.
+
+Sign in with...
+```
+ssh WarrenLab@warwulf.net
+```
+
+Load VASP with...
+```
+module purge
+module load gnu11 impi vasp libfabric ucx
+```
+
+Call VASP with... (we don't use `vasp_std` for our default command)
+```
+vasp > vasp.out 
+```
+
+Create your conda env with...
+```
+conda create -n my_env -c conda-forge python=3.8 simmate
+conda activate my_env
+
+# SEE WARNING BELOW -- skip the database reset
+```
+
+:warning::warning::warning:
+Do **NOT** run the `simmate database reset`. Because we share a username, we share a home directory and database. Calling this command will reset EVERYONE's database. If you think the database needs reset, contact Scott first.
+:warning::warning::warning:
+
+
+Switch to the temporary working directory before submitting:
+```
+cd /media/synology/user/your_name
+```
+
+
+Create a SLURM script with...
+```
+nano submit.sh
+```
+
+And paste in the example content...
+```
+#!/bin/bash
+
+#. /opt/ohpc/pub/suppress.sh  #supress infiniband output, set vasp path
+
+#SBATCH --job-name=my_example_job
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=4GB
+#SBATCH --time=01:00:00
+#SBATCH --partition=p1
+#SBATCH --output=slurm.out 
+#SBATCH --mail-type=ALL 
+#SBATCH --mail-user=my_username@live.unc.edu
+
+simmate workflows run energy_mit POSCAR -c "mpirun -n 4 vasp_std > vasp.out"
+```
+
+Check list before submitting:
+1. loaded the VASP module
+2. activated your conda environment
+3. in the temporary working directory (/media/synology/user/your_name)
+4. created `submit.sh` and editted contents as needed
+5. structure file (e.g. `POSCAR`) is present in working directory
+
+Once all of these are met, you can submit with...
+```
+sbatch submit.sh
+```
+
+Monitor progress with... (a short cut for `squeue` with extra info)
+```
+sq
+```

--- a/tutorials/Guides_for_HPC_clusters/WarWulf.md
+++ b/tutorials/Guides_for_HPC_clusters/WarWulf.md
@@ -3,11 +3,11 @@
 
 WarWulf is the Warren Lab's Beowulf cluster.
 
-# Guide
+> :bulb: This guide should be used alongside tutorial 02 ([here](https://github.com/jacksund/simmate/blob/main/tutorials/02_%20Run_a_workflow.md#switching-to-a-remote-cluster)).
 
-This guide should be used alongside tutorial 02 when switching to a remote cluster ([here](https://github.com/jacksund/simmate/blob/main/tutorials/02_%20Run_a_workflow.md#switching-to-a-remote-cluster)).
+<br/>
 
-## The Simmate checklist
+# The Simmate checklist
 
 From the posted requirements:
 
@@ -23,27 +23,38 @@ For the uncompleted requirements:
 2. everyone shares the profile "WarrenLab". Ask Scott for the password (scw@email.unc.edu)
 5. make your personal environment named `yourname_env` (e.g. `jacks_env`)
 
-## Example commands and scripts
+<br/>
+
+# Example commands and scripts
 
 Substitute these commands with the ones you see in the main tutorial.
 
-Sign in with...
+<br/>
+
+## Sign in with...
 ```
 ssh WarrenLab@warwulf.net
 ```
 
-Load VASP with...
+<br/>
+
+## Load VASP with...
 ```
 module purge
 module load gnu11 impi vasp libfabric ucx
 ```
 
-Call VASP with... (we don't use `vasp_std` for our default command)
+<br/>
+
+## Call VASP with... 
+We don't use `vasp_std` for our default command.
 ```
 vasp > vasp.out 
 ```
 
-Create your conda env with...
+<br/>
+
+## Create your conda env with...
 ```
 conda create -n my_env -c conda-forge python=3.8 simmate
 conda activate my_env
@@ -55,17 +66,21 @@ conda activate my_env
 Do **NOT** run the `simmate database reset`. Because we share a username, we share a home directory and database. Calling this command will reset EVERYONE's database. If you think the database needs reset, contact Scott first.
 :warning::warning::warning:
 
+<br/>
 
-Switch to the temporary working directory before submitting:
+## Access scratch directory with...
 ```
 cd /media/synology/user/your_name
 ```
 
+<br/>
 
-Create a SLURM script with...
+## Create a SLURM script with...
 ```
 nano submit.sh
 ```
+
+<br/>
 
 And paste in the example content...
 ```
@@ -87,7 +102,10 @@ And paste in the example content...
 simmate workflows run energy_mit POSCAR -c "mpirun -n 4 vasp_std > vasp.out"
 ```
 
-Check list before submitting:
+<br/>
+
+## Submit with...
+Checklist before submitting:
 1. loaded the VASP module
 2. activated your conda environment
 3. in the temporary working directory (/media/synology/user/your_name)
@@ -99,7 +117,10 @@ Once all of these are met, you can submit with...
 sbatch submit.sh
 ```
 
-Monitor progress with... (a short cut for `squeue` with extra info)
+<br/>
+
+## Monitor progress with... 
+We use a short cut for `squeue` with extra info
 ```
 sq
 ```


### PR DESCRIPTION
- [x] cluster specific directions (vasp and submit.sh)
- [x] vasp potcars (separate section, give folder tree + where you can find them)
- [x] format commands on separate lines + commend of if it's python/terminal
- [x] expected outputs for python
- [x] update output of simmate command in tutorial 1
- [x] links to next tutorials
- [x] more relevant photos for spyder screenshot (tut 04)
- [x]  submit.sh script that utilizes the mpirun command. maybe  explain a bit more of the submit.sh info.
- [x] Tutorial 3 Quick version doesn't match long version
- [x] is_matching = matcher.fit(structure1, structure2)  --> doesn't print out true/false
- [x] (Tutorial 4) To prove it, let's go through these steps: run import simmate in your python terminal. get the help docs for simmate in the Spyder help window  <-- include a hint of Ctrl + I
- [x] Navigate through the folders. simmate --> toolkit --> core --> lattice.py.        <-- Not core.   actually base_data_types
- [x] Posting a question didn't work correctly (if not signed in)
- [x] unhide simmate base directory

For WarWulf...
```
module purge
module load gnu11 impi vasp libfabric ucx
conda install -n my_env -c conda-forge -c conda-forge/label/simmate_dev simmate

vasp > vasp.out  # instead of vasp_std
```
