### PR TITLE
:books: update docs for all parameters

### DIFF
--- a/src/simmate/command_line/workflows.py
+++ b/src/simmate/command_line/workflows.py
@@ -166,6 +166,13 @@ def explore():
     print(f"{prefix}Parameters:\n")
     workflow.show_parameters()
 
+    endnote = Markdown(
+        "To understand each parameter, you can read through "
+        "[our parameter docs](https://jacksund.github.io/simmate/simmate/workflows.html#parameters)"
+        ", which give full descriptions and examples."
+    )
+    console.print(endnote)
+
     print(f"{prefix}==================================================================")
 
 

--- a/src/simmate/toolkit/diffusion/migration_images.py
+++ b/src/simmate/toolkit/diffusion/migration_images.py
@@ -330,7 +330,7 @@ class MigrationImages(list):
         """
         is_from_past_calc = False
 
-        # assume any list is in the MigrationHop format if there are more than
+        # assume any list is in the MigrationImages format if there are more than
         # two structures (i.e. there is at least one midpoint image)
         if isinstance(migration_images, cls):
             migration_images_cleaned = migration_images

--- a/src/simmate/workflow_engine/workflow.py
+++ b/src/simmate/workflow_engine/workflow.py
@@ -768,7 +768,11 @@ class Workflow:
     @classmethod
     @property
     def all_results(cls):  # -> SearchResults
-        return cls.database_table.objects.filter(workflow_name=cls.name_full).all()
+        # BUG: pdoc raises an error because name_full fails.
+        try:
+            return cls.database_table.objects.filter(workflow_name=cls.name_full).all()
+        except:
+            return
 
     @classmethod
     def _save_to_database(cls, result: any, run_id: str):

--- a/src/simmate/workflow_engine/workflow.py
+++ b/src/simmate/workflow_engine/workflow.py
@@ -766,8 +766,9 @@ class Workflow:
             raise NotImplementedError("Unable to detect proper database table")
 
     @classmethod
+    @property
     def all_results(cls):  # -> SearchResults
-        return cls.database_table.objects.filter(workflow_name=cls.name_full)
+        return cls.database_table.objects.filter(workflow_name=cls.name_full).all()
 
     @classmethod
     def _save_to_database(cls, result: any, run_id: str):

--- a/src/simmate/workflows/README.md
+++ b/src/simmate/workflows/README.md
@@ -2,24 +2,38 @@
 
 This module brings together all predefined workflows and organizes them by application for convenience.
 
+This module covers basic use, but more information is available in `simmate.workflow_engine.workflow`.
+
 
 # Basic use
 
 [Tutorials 01-05](https://github.com/jacksund/simmate/tree/main/tutorials) will teach you how to run workflows and access their results. But as a review:
 
 ``` python
-from simmate.workflows.all import StaticEnergy__Vasp__Matproj as workflow
+from simmate.workflows.static_energy import StaticEnergy__Vasp__Matproj as workflow
 
 # runs the workflow and returns a state
 state = workflow.run(structure="my_structure.cif")
 result = state.result()
 
 # gives the DatabaseTable where ALL results are stored
-workflow.database_table
-df = workflow.database_table.objects.to_dataframe()  # convert to pandas dataframe
+workflow.database_table  # --> gives all relaxation results
+workflow.all_results  # --> gives all results for this relaxation preset
+df = workflow.all_results.to_dataframe()  # convert to pandas dataframe
 ```
 
 Further information on interacting with workflows can be found in the `simmate.workflow_engine` module as well -- particularly, the `simmate.workflow_engine.workflow` module.
+
+
+# Avoiding long import paths
+
+If you are a regular python user, you'll notice the import path above is long and unfriendly. If you'd like to avoid importing this way, you can instead use the `get_workflow` utility:
+
+``` python
+from simmate.workflows.utilities import get_workflow
+
+workflow = get_workflow("static-energy.vasp.matproj")
+```
 
 
 # Workflow naming conventions
@@ -32,10 +46,9 @@ All workflow names follow a specific format of `Type__Calculator__Preset` so for
 
 The workflow name can also be used to infer where the workflow is located in python. For `StaticEnergy__Vasp__Matproj`, this corresponds to a name of `static-energy.vasp.matproj` and means the workflow can be accessed in the following ways:
 
-1. `from simmate.workflows.all import StaticEnergy__Vasp__Matproj` (easiest to remember import)
-2. `from simmate.workflows.static_energy import StaticEnergy__Vasp__Matproj` (uses the `type`)
-3. `from simmate.calculators.vasp.workflows.static_energy.all import StaticEnergy__Vasp__Matproj`  (uses the `type` and `calculator`)
-4. `from simmate.calculators.vasp.workflows.static_energy.matproj import StaticEnergy__Vasp__Matproj`  (uses the `type` and `calculator` and `preset`)
+1. `from simmate.workflows.static_energy import StaticEnergy__Vasp__Matproj` (uses the `type`)
+2. `from simmate.calculators.vasp.workflows.static_energy.all import StaticEnergy__Vasp__Matproj`  (uses the `type` and `calculator`)
+3. `from simmate.calculators.vasp.workflows.static_energy.matproj import StaticEnergy__Vasp__Matproj`  (uses the `type` and `calculator` and `preset`)
 
 These imports all give the same workflow, but we recommend stick to the first option because it is the most convienent and easiest to remember. The only reason you'll need to interact with the other options is to either:
 
@@ -69,3 +82,261 @@ from simmate.calculators.{CALCULATOR}.workflows.{TYPE}.{PRESET} import {FULL_NAM
 # Example with StaticEnergy__Vasp__Matproj
 from simmate.calculators.vasp.workflows.static_energy.matproj import StaticEnergy__Vasp__Matproj
 ```
+
+# Parameters
+
+Knowing which parameters are available and how to use them is essential to use Simmate to the fullest. We therefore outline ALL unique parameters for ALL workflows here.
+
+To see which parameters are allow for a given workflow, you can use the `simmate explore` command to list them. Alternatively, in python, you can use `workflow.show_parameters()`.
+
+For example:
+
+```
+workflow.show_parameters()
+
+- command
+- compress_output
+- directory
+- is_restart
+- pre_sanitize_structure
+- pre_standardize_structure
+- run_id
+- source
+- structure
+```
+
+You can then search for these parameters below to learn more about them.
+
+
+## command
+The command that will be called during execution of a program. There is typically a default set for this that you only need to change unless you'd like parallelization. For example, VASP workflows use `vasp_std > vasp.out` by default but you can override this to use `mpirun`.
+``` python
+# python example
+command="mpirun -n 8 vasp_std > vasp.out"
+```
+``` yaml
+# yaml file example
+command: mpirun -n 8 vasp_std > vasp.out
+```
+
+
+## composition
+The composition input can be anything compatible with the `Composition` toolkit class. Note that compositions are sensitive to atom counts / multiplicity. There is a difference between giving `Ca2N` and `Ca4N2` in several workflows. Accepted inputs include:
+
+- a string (recommended)
+``` python
+# python example
+composition="Ca2NF"
+```
+``` yaml
+# yaml file example
+composition: Ca2NF
+```
+
+- a dictionary that gives the composition
+``` python
+# python example
+composition={"Ca": 2, "N": 1, "F": 1}
+```
+``` yaml
+# yaml file example
+composition:
+    Ca: 2
+    N: 1
+    F: 1
+```
+
+- a `Composition` object (best for advanced logic)
+``` python
+# python example
+from simmate.toolkit import Compositon
+
+composition = Composition("Ca2NF")
+```
+
+- json/dictionary serialization from pymatgen
+
+
+## compress_output
+Whether to compress the `directory` to a zip file at the end of the run. After compression, it will also delete the directory. The default is False.
+``` python
+# python example
+compress_output=True
+```
+``` yaml
+# yaml file example
+command: true
+```
+
+
+## copy_previous_directory
+Whether to copy the directory from the previous calculation (if there is one) and then use it as a starting point for this new calculation. This is only possible if you provided an input that points to a previous calculation. For example, `structure` would need to use a database-like input:
+``` python
+# python example
+structure = {"database_table": "Relaxation", "database_id": 123}
+copy_previous_directory=True
+```
+``` yaml
+# yaml file example
+structure:
+    database_table: Relaxation
+    database_id: 123
+copy_previous_directory: true
+```
+
+The default is `False`, and it is not recommended to use this in existing workflows. Nested workflows that benefit from this feature use it automatically.
+
+
+## diffusion_analysis_id
+(advanced users only) The entry id from the `DiffusionAnalysis` table to link the results to. This is set automatically by higher-level workflows and rarely (if ever) set by the user.
+
+
+## directory
+The directory to run everything in -- either as a relative or full path. This is passed to the ulitities function `simmate.ulitities.get_directory`, which generates a unique foldername if not provided (such as `simmate-task-12390u243`). This will be converted into a `pathlib.Path` object. Accepted inputs include:
+
+- leave as default (recommended)
+
+- a string
+``` python
+# python example
+directory = "my-new-folder-00"
+```
+``` yaml
+# yaml file example
+directory: my-new-folder-00
+```
+
+- a `pathlib.Path` (best for advanced logic)
+
+``` python
+# python example
+from pathlib import Path
+
+directory = Path("my-new-folder-00")
+```
+
+
+## directory_new
+Unique to the `restart.simmate.automatic` workflow, this is the folder that the workflow will be continued in. Follows the same rules/inputs as the `directory` parameter.
+
+
+## directory_old
+Unique to the `restart.simmate.automatic` workflow, this is the original folder that should be used at the starting point. Follows the same rules/inputs as the `directory` parameter.
+
+
+## fitness_field
+(advanced users only) For evolutionary searches, this is the value that should be optimized. Specifically, it should minimized this value (lower value = better fitness). The default is `energy_per_atom`, but you may want to set this to a custom column in a custom database table.
+
+
+## input_parameters
+(experimental feature) Unique to `customized.vasp.user-config`. This is a list of parameters to pass to `workflow_base`.
+
+
+## is_restart
+(experimental feature) Whether the calculation is a restarted workflow run. Default is False. If set to true, the workflow will go through the given directory (which must be provided) and see where to pick up.
+``` python
+# python example
+directory = "my-old-calc-folder"
+is_restart = True
+```
+``` yaml
+# yaml file example
+directory: my-old-calc-folder
+is_restart: true
+```
+
+
+## limit_best_survival
+For evolutionary searches, fixed compositions will be stopped when the best individual remains unbeaten for this number of new individuals. The default is typically set based on the number of atoms in the composition.
+``` python
+# python example
+limit_best_survival = 100
+```
+``` yaml
+# yaml file example
+limit_best_survival: 100
+```
+
+## max_atoms
+For workflows that involve generating a supercell or random structure, this will be the maximum number of sites to allow in the generate structure(s). For example, NEB workflows would set this value to something like 100 atoms to limit their supercell image sizes. Alternatively, a evolutionary search may set this to 10 atoms to limit the compositions & stoichiometries that are explored.
+``` python
+# python example
+max_atoms = 100
+```
+``` yaml
+# yaml file example
+max_atoms: 100
+```
+
+## max_structures
+
+## migrating_specie
+
+## migration_hop
+
+## migration_hop_id
+
+## migration_images
+
+
+## min_atoms
+This is the opposite of `max_atoms` as this will be the minimum number of sites to allow in the generate structure(s). See `max_atoms` for details.
+
+
+## min_length
+
+## nfirst_generation
+
+## nimages
+
+## nsteadystate
+
+## nsteps
+
+## pre_sanitize_structure
+
+## pre_standardize_structure
+
+## run_id
+
+## search_id
+
+## selector_kwargs
+
+## selector_name
+
+## singleshot_sources
+
+## sleep_step
+
+## source
+
+## steadystate_sources
+
+## structure
+
+## structure_source_id
+
+## subworkflow_kwargs
+
+## subworkflow_name
+
+## supercell_end
+
+## supercell_start
+
+## tags
+
+## temperature_end
+
+## temperature_start
+
+## time_step
+
+## updated_settings
+
+## validator_kwargs
+
+## validator_name
+
+## workflow_base

--- a/src/simmate/workflows/README.md
+++ b/src/simmate/workflows/README.md
@@ -87,9 +87,14 @@ from simmate.calculators.vasp.workflows.static_energy.matproj import StaticEnerg
 
 Knowing which parameters are available and how to use them is essential to use Simmate to the fullest. We therefore outline ALL unique parameters for ALL workflows here.
 
-To see which parameters are allow for a given workflow, you can use the `simmate explore` command to list them. Alternatively, in python, you can use `workflow.show_parameters()`.
+To see which parameters are allow for a given workflow, you can use the explore command to list them:
 
-For example:
+``` bash
+simmate workflows explore
+```
+
+
+Alternatively, in python, you can use `workflow.show_parameters()`. For example:
 
 ```
 workflow.show_parameters()
@@ -269,14 +274,69 @@ max_atoms: 100
 ```
 
 ## max_structures
+For workflows that generate new structures (and potentially run calculations on them), this will be the maximum number of structures allowed. The workflow will end at this number of structures regardless of whether the calculation/search is converged or not.
+``` python
+# python example
+max_structures = 100
+```
+``` yaml
+# yaml file example
+max_structures: 100
+```
 
 ## migrating_specie
+This is the atomic species/element that will be moving in the analysis (typically NEB or MD diffusion calculations). Note, oxidation states (e.g. "Ca2+") can be used, but this requires your input structure to be oxidation-state decorated as well.
+``` python
+# python example
+migrating_specie = "Li"
+```
+``` yaml
+# yaml file example
+migrating_specie: Li
+```
+
 
 ## migration_hop
+(advanced users only) The atomic path that should be analyzed. Inputs are anything compatible with the `MigrationHop` class of the `simmate.toolkit.diffusion` module. This includes:
+
+- `MigrationHop` object
+- a database entry in the `MigrationHop` table
+
+(TODO: if you'd like full examples, please ask our team to add them)
+
 
 ## migration_hop_id
+(advanced users only) The entry id from the `MigrationHop` table to link the results to. This is set automatically by higher-level workflows and rarely (if ever) set by the user. If used, you'll likely need to set `diffusion_analysis_id` as well.
+
 
 ## migration_images
+The full set of images (including endpoint images) that should be analyzed. Inputs are anything compatible with the `MigrationImages` class of the `simmate.toolkit.diffusion` module, which is effectively a list of `structure` inputs. This includes:
+
+- `MigrationImages` object
+
+- a list of `Structure` objects
+
+- a list of filenames (cif or POSCAR)
+``` python
+# python example
+migration_images = [
+    "image_01.cif",
+    "image_02.cif",
+    "image_03.cif",
+    "image_04.cif",
+    "image_05.cif",
+]
+```
+``` yaml
+# yaml file example
+migration_images:
+    - image_01.cif
+    - image_02.cif
+    - image_03.cif
+    - image_04.cif
+    - image_05.cif
+```
+
 
 
 ## min_atoms
@@ -284,12 +344,51 @@ This is the opposite of `max_atoms` as this will be the minimum number of sites 
 
 
 ## min_length
+When generating a supercell, this is the minimum length for each lattice vector of the generate cell (in Angstroms).
+``` python
+# python example
+min_length = 7.5
+```
+``` yaml
+# yaml file example
+min_length: 7.5
+```
 
 ## nfirst_generation
+For evolutionary searches, no mutations or "child" individuals will be scheduled until this
+number of individuals have been calculated. This ensures we have a good pool of candidates calculated before we start selecting parents and mutating them.
+``` python
+# python example
+nfirst_generation = 15
+```
+``` yaml
+# yaml file example
+nfirst_generation: 15
+```
 
 ## nimages
+The number of images (or structures) to use in the analysis. This does NOT include the endpoint images (start/end structures). More is better, but computationally expensive. We recommend keeping this value odd in order to ensure there is an image at the midpoint.
+``` python
+# python example
+nimages = 5
+```
+``` yaml
+# yaml file example
+nimages: 5
+```
+WARNING: For calculators such as VASP, your `command` parameter must use a number of cores that is divisible by `nimages`. For example, `nimages=3` and `command="mpirun -n 10 vasp_std > vasp.out"` will fail because 10 is not divisible by 3.
+
 
 ## nsteadystate
+The number of individual workflows to have scheduled at once. This therefore sets the queue size of an evolutionary search. Note, the number of workflows ran in parallel is determined by the number of `Workers` started (i.e. starting 3 workers will run 3 workflows in parallel, even if 100 workflows are in the queue). The steady-state does, however, set the **maximum** number of parallel runs because the queue size will never exceed the `nsteadystate` value. This parameter is closely tied with `steadystate_sources`, so be sure to read about that parameter as well.
+``` python
+# python example
+nsteadystate = 50
+```
+``` yaml
+# yaml file example
+nsteadystate: 50
+```
 
 ## nsteps
 

--- a/src/simmate/workflows/README.md
+++ b/src/simmate/workflows/README.md
@@ -561,6 +561,70 @@ singleshot_sources:
 
 
 ## structure
+The crystal structure to be used for the analysis. The input can be anything compatible with the `Structure` toolkit class. Accepted inputs include:
+
+- a filename (cif or poscar) (recommended)
+``` python
+# python example
+structure="NaCl.cif"
+```
+``` yaml
+# yaml file example
+structure: NaCl.cif
+```
+
+- a dictionary that points to a database entry. Note, instead of `database_id`, you can also use the `run_id` or `directory` to indicate which entry to load. Further, if the database table is linked to multiple structures (e.g. relaxations have a `structure_start` and `structure_final`), then you can also add the `structure_field` to specify which to choose. 
+``` python
+# python examples
+
+# example 1
+structure={
+    "database_table": "MatprojStructure",
+    "database_id": "mp-123",
+}
+
+# example 2
+structure={
+    "database_table": "StaticEnergy",
+    "database_id": 50,
+}
+
+# example 3
+structure={
+    "database_table": "Relaxation",
+    "database_id": 50,
+    "structure_field": "structure_final",
+}
+```
+``` yaml
+# yaml file example
+structure:
+    database_table: MatprojStructure
+    database_id: mp-123
+```
+
+- a `Structure` object (best for advanced logic)
+``` python
+# python example
+from simmate.toolkit import Structure
+
+structure = Structure(
+    lattice=[
+        [2.846, 2.846, 0.000],
+        [2.846, 0.000, 2.846],
+        [0.000, 2.846, 2.846],
+    ],
+    species=["Na", "Cl"],
+    coords=[
+        [0.5, 0.5, 0.5],
+        [0.0, 0.0, 0.0],
+    ],
+    coords_are_cartesian=False,
+)
+```
+
+- json/dictionary serialization from pymatgen
+
 
 ## structure_source_id
 (advanced users only)


### PR DESCRIPTION
- makes progress on #147 

@scott-materials @laurenmm @becca9835

This PR will help a bunch with figuring out workflow parameters and how to use them. Once it's merged, you'll want to read through [the documentation for the workflow module](https://jacksund.github.io/simmate/simmate/workflows.html#parameters). (try this link after merging and it will bring you right to the relevant section).

I think there are a lot of features that I've built into the workflow yaml files that are overlooked because the documentation is difficult to find for each workflow. For example, one cool feature that I don't think anyone knows about is that you can run a workflow with a materials project structure -- without ever going to their website or even making a cif/poscar file:

``` yaml
workflow_name: static-energy.vasp.mit
structure:
    database_table: MatprojStructure
    database_id: mp-1234
```

Definitely read through the `structure` parameter setting once this is merged.
