### PR TITLE
:fire_engine: update workflow engine

### DIFF
--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -74,6 +74,7 @@ There is one key exception to the rules above -- and that is with `MAJOR`=0 rele
 - add `simmate version` command
 - changelog and update guide added to documentation website
 - add `show-stats`, `delete-finished`, and `delete-all` commands to `workflow-engine`
+- add `Cluster` base class + commands that allow submitting a steady-state cluster via subprocesses or slurm
 
 
 --------------------------------------------------------------------------------

--- a/docs/change_log.md
+++ b/docs/change_log.md
@@ -73,6 +73,7 @@ There is one key exception to the rules above -- and that is with `MAJOR`=0 rele
 - add structure creators for `ASE`, `GASP`, `PyXtal`, `AIRSS`, `CALYPSO`, `USPEX`, and `XtalOpt` as well as documentation for creators.
 - add `simmate version` command
 - changelog and update guide added to documentation website
+- add `show-stats`, `delete-finished`, and `delete-all` commands to `workflow-engine`
 
 
 --------------------------------------------------------------------------------

--- a/src/simmate/command_line/workflow_engine.py
+++ b/src/simmate/command_line/workflow_engine.py
@@ -79,15 +79,18 @@ def start_singleflow_worker():
 @workflow_engine_app.command()
 def start_cluster(
     nworkers: int,
-    worker_command: str = "simmate workflow-engine start-worker",
+    type: str = "local",
+    continuous: bool = False,
 ):
     """
     This starts many Simmate Workers that each run in a local subprocess
 
     - `nworkers`: the number of workers to start
 
-    - `worker_command`: the command to start each worker with. See start-worker
-    for options
+    - `cluster_type`: where to submit workers (either local or slurm)
+
+    - `continuous`: whether to do a single submission of workers or hold nworkers
+    at a steady-state number (runs endlessly)
 
     """
 
@@ -95,7 +98,8 @@ def start_cluster(
 
     start_cluster(
         nworkers=nworkers,
-        worker_command=worker_command,
+        cluster_type=type,
+        continuous=continuous,
     )
 
 

--- a/src/simmate/command_line/workflow_engine.py
+++ b/src/simmate/command_line/workflow_engine.py
@@ -107,3 +107,33 @@ def show_error_summary():
     from simmate.workflow_engine.execution import SimmateExecutor
 
     SimmateExecutor.show_error_summary()
+
+
+@workflow_engine_app.command()
+def show_stats():
+    """
+    Prints a summary of different workitems and their status
+    """
+    from simmate.workflow_engine.execution import SimmateExecutor
+
+    SimmateExecutor.show_stats()
+
+
+@workflow_engine_app.command()
+def delete_finished(confirm: bool = False):
+    """
+    Prints a summary of different workitems and their status
+    """
+    from simmate.workflow_engine.execution import SimmateExecutor
+
+    SimmateExecutor.delete_finished(confirm)
+
+
+@workflow_engine_app.command()
+def delete_all(confirm: bool = False):
+    """
+    Prints a summary of different workitems and their status
+    """
+    from simmate.workflow_engine.execution import SimmateExecutor
+
+    SimmateExecutor.delete_all(confirm)

--- a/src/simmate/workflow_engine/execution/cluster/__init__.py
+++ b/src/simmate/workflow_engine/execution/cluster/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from .local import LocalCluster
+from .slurm import SlurmCluster

--- a/src/simmate/workflow_engine/execution/cluster/base.py
+++ b/src/simmate/workflow_engine/execution/cluster/base.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import time
+
+
+class Cluster:
+    @classmethod
+    def start_cluster(cls, nworkers: int, sleep_step: float = 5):
+
+        logging.info(f"Starting cluster with {nworkers} workers")
+
+        # on start-up we need to submit the target number of jobs
+        job_ids = cls.submit_jobs(nworkers)
+
+        # we now monitor the jobs running and submit new workers whenever
+        # we drop below out target.
+        # We do this endlessly until the user closes the script
+        while True:
+            job_ids = cls.update_jobs_list(job_ids)
+            njobs_needed = nworkers - len(job_ids)
+            if njobs_needed > 0:
+                cls.submit_jobs(njobs_needed)
+            # only check this list every sleep cycle
+            time.sleep(sleep_step)
+
+    @classmethod
+    def wait_for_jobs(cls, job_ids: list[int], sleep_step: float = 5):
+
+        # loop until the job id list is empty
+        while job_ids:
+            job_ids = cls.update_jobs_list(job_ids)
+            time.sleep(sleep_step)
+
+    @classmethod
+    def submit_jobs(cls, njobs: int) -> list[int]:
+        """
+        Calls submit_to_queue a set number of times and returns the new job ids
+        """
+        job_ids = [cls.submit_job() for n in range(njobs)]
+        logging.info(f"{njobs} new workers have been submitted")
+        return job_ids
+
+    @staticmethod
+    def submit_job() -> int:
+        """
+        Submits a new job to the queue and returns the job id
+        """
+        raise NotImplementedError(
+            "add a custom submit_job method to your cluster class"
+        )
+
+    @staticmethod
+    def update_jobs_list(job_ids: list[int]) -> int:
+        """
+        Given a list of job ids, it will check which ones are still running and
+        which are finished. It will then return a list of the job id that are
+        still running.
+        """
+        raise NotImplementedError(
+            "add a custom update_jobs_list method to your cluster class"
+        )

--- a/src/simmate/workflow_engine/execution/cluster/local.py
+++ b/src/simmate/workflow_engine/execution/cluster/local.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+
+import subprocess
+from pathlib import Path
+from tempfile import mkstemp
+
+from simmate.workflow_engine.execution.cluster.base import Cluster
+
+
+class LocalCluster(Cluster):
+    """
+    Submits workers via subprocesses
+    """
+
+    worker_command: str = "simmate workflow-engine start-worker"
+
+    @classmethod
+    def submit_job(cls) -> subprocess.Popen:
+
+        output_file = (
+            Path.cwd()
+            / mkstemp(
+                prefix="simmate-worker-",
+                suffix=".out",
+                dir=Path.cwd(),
+            )[1]
+        )
+
+        popen = subprocess.Popen(
+            cls.worker_command,
+            shell=True,
+            stdout=output_file.open("w"),
+            stderr=output_file.open("w"),
+        )
+        return popen
+
+    @staticmethod
+    def update_jobs_list(job_ids: list[subprocess.Popen]) -> list[subprocess.Popen]:
+
+        # each job id is actually a subprocess.Popen object
+        still_running = []
+        for process in job_ids:
+            if process.poll() is None:
+                # p.subprocess is alive
+                still_running.append(process)
+
+        return still_running

--- a/src/simmate/workflow_engine/execution/cluster/slurm.py
+++ b/src/simmate/workflow_engine/execution/cluster/slurm.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+import subprocess
+
+from simmate.workflow_engine.execution.cluster.base import Cluster
+
+
+class SlurmCluster(Cluster):
+    """
+    Submits workers via a submit.sh file (in the working directory) and to
+    a SLURM cluster.
+    """
+
+    @staticmethod
+    def submit_job() -> int:
+        """
+        Submits a new job to the queue and returns the job id
+        """
+        process = subprocess.run(
+            "sbatch submit.sh",
+            shell=True,
+            capture_output=True,
+            text=True,
+        )
+        job_id = int(process.stdout.strip().split()[-1])
+        return job_id
+
+    @staticmethod
+    def update_jobs_list(job_ids: list[int]) -> list[int]:
+        """
+        Given a list of job ids, it will check which ones are still running and
+        which are finished. It will then return a list of the job id that are
+        still running.
+        """
+
+        # OPTIMIZE: is there a way to queue a list of ids?
+        still_running = []
+        for job_id in job_ids:
+            process = subprocess.run(
+                f"squeue -j {job_id}",
+                shell=True,
+            )
+            # an error is return if the job is no longer in the queue.
+            if process.returncode == 0:
+                still_running.append(job_id)
+
+        return still_running

--- a/src/simmate/workflow_engine/execution/executor.py
+++ b/src/simmate/workflow_engine/execution/executor.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 
 import logging
+from datetime import timedelta
 
 import cloudpickle  # needed to serialize Prefect workflow runs and tasks
+from django.utils import timezone
 from rich import print
 
 from simmate.workflow_engine.execution.database import WorkItem
@@ -104,29 +106,34 @@ class SimmateExecutor:
         return queue_size
 
     @staticmethod
-    def clear_queue(are_you_sure: bool = False):
+    def delete_all(confirm: bool = False):
         """
         Empties the WorkItem database table and delete everything. This will
         not stop the workers if they are in the middle of a job though.
         """
         # Make sure the user ment to do this, otherwise raise an exception
-        if not are_you_sure:
+        if not confirm:
             raise Exception(
-                "Are you sure you want to do this? it deletes all of your queue"
-                "data and you can't get it back. If so, set are_you_sure=True."
+                "Are you sure you want to do this? This deletes all of your queue "
+                "data and you can't get it back. If so, run this method again "
+                "with confirmation."
             )
         else:
             WorkItem.objects.all().delete()
 
     @staticmethod
-    def clear_finished(are_you_sure: bool = False):
+    def delete_finished(confirm: bool = False):
         """
         Empties the WorkItem database table and delete everything. This will
         not stop the workers if they are in the middle of a job though.
         """
         # Make sure the user ment to do this, otherwise raise an exception
-        if not are_you_sure:
-            raise Exception
+        if not confirm:
+            raise Exception(
+                "Are you sure you want to do this? This deletes finished "
+                "entries from your queue-table and you can't get them back. "
+                "If so, run this method again with confirmation."
+            )
         else:
             WorkItem.objects.filter(status="F").delete()
 
@@ -146,6 +153,27 @@ class SimmateExecutor:
                 job.result()
             except Exception as error:
                 print(f"{job.id} | {error}")
+
+    @staticmethod
+    def show_stats() -> int:
+        npending = WorkItem.objects.filter(status="P").count()
+        nrunning = WorkItem.objects.filter(status="R").count()
+        ncanceled = WorkItem.objects.filter(status="C").count()
+        nfinished = WorkItem.objects.filter(status="F").count()
+        nerrored = WorkItem.objects.filter(status="E").count()
+
+        error_percent = (nerrored / (nerrored + nfinished)) * 100
+
+        nrunning_long = WorkItem.objects.filter(
+            status="R",
+            updated_at__lte=timezone.now() - timedelta(days=1),
+        ).count()
+
+        print(f"PENDING:   {npending}")
+        print(f"RUNNING:   {nrunning} ({nrunning_long} for +24hrs)")
+        print(f"FINISHED:  {nfinished}")
+        print(f"ERRORED:   {nerrored} ({error_percent:.2f}%)")
+        print(f"CANCELED:  {ncanceled}")
 
     # -------------------------------------------------------------------------
     # Extra methods to add if I want to be consistent with other Executor classes

--- a/src/simmate/workflow_engine/execution/executor.py
+++ b/src/simmate/workflow_engine/execution/executor.py
@@ -162,7 +162,10 @@ class SimmateExecutor:
         nfinished = WorkItem.objects.filter(status="F").count()
         nerrored = WorkItem.objects.filter(status="E").count()
 
-        error_percent = (nerrored / (nerrored + nfinished)) * 100
+        if nfinished:
+            error_percent = (nerrored / (nerrored + nfinished)) * 100
+        else:
+            error_percent = 0
 
         nrunning_long = WorkItem.objects.filter(
             status="R",

--- a/src/simmate/workflow_engine/execution/utilities.py
+++ b/src/simmate/workflow_engine/execution/utilities.py
@@ -1,69 +1,27 @@
 # -*- coding: utf-8 -*-
 
-import logging
-import subprocess
-from pathlib import Path
-from tempfile import mkdtemp
+from simmate.workflow_engine.execution.cluster import LocalCluster, SlurmCluster
 
 
 def start_cluster(
     nworkers: int,
-    worker_command: str = "simmate workflow-engine start-worker",
+    cluster_type: str = "local",
+    continuous: bool = False,
 ):
+    """
+    Utilitiy that helps set up common cluster types with a specific number of
+    workers and optionally run a single-submit of workers
+    """
+    if cluster_type == "local":
+        cluster = LocalCluster
+    elif cluster_type == "slurm":
+        cluster = SlurmCluster
+    else:
+        raise Exception(f"Unknown cluster type {cluster_type}. Choose local or slurm.")
 
-    cluster_directory = mkdtemp(prefix="simmate-cluster-", dir=Path.cwd())
-
-    logging.info(f"Starting up cluster in {cluster_directory}")
-
-    # For as many workers that were requested, go through and start that many
-    # subprocesses for individual workers.
-    all_popens = []
-    for n in range(nworkers):
-
-        output_file = Path.cwd() / cluster_directory / f"worker_{n}.out"
-
-        popen = subprocess.Popen(
-            worker_command,
-            shell=True,
-            stdout=output_file.open("w"),
-            stderr=output_file.open("w"),
-        )
-        all_popens.append(popen)
-
-    logging.info(f"A total of {nworkers} workers have been started.")
-    logging.info("Waiting until all workers workers shut down...")
-
-    # Now just wait for the process to finish. Note we use communicate
-    # instead of the .wait() method. This is the recommended method
-    # when we have stderr=subprocess.PIPE, which we use above.
-    [popen.communicate() for popen in all_popens]
-
-    logging.info("All workers have terminated. Shutting down.")
-
-
-# For SLURM, PBS, etc., I should refactor the strategy used by FireWorks:
-#   https://github.com/materialsproject/fireworks/tree/main/fireworks/queue
-#
-# I tried a hacky approah using dask-jobqueue, but it was just too messy and
-# buggy to use in production:
-#
-# from simmate.configuration.dask import get_dask_client
-# from dask.distributed import as_completed
-# n_workers = 5
-# client = get_dask_client(n_workers=n_workers, threads_per_worker=1)
-# futures = []
-# for dask_id, dask_worker in client.cluster.workers.items():
-#     future = client.submit(
-#         subprocess.run,
-#         f"simmate workflow-engine start-singleflow-worker > worker_{dask_id}.out",
-#         shell=True,
-#         # capture_output=True,
-#         pure=False,
-#         workers=[dask_id],
-#     )
-#     future.worker_id = dask_id  # for reference later
-#     future.worker_nanny = dask_worker  # for reference later
-#     futures.append(future)
-# for future in as_completed(futures):
-#     print("restarting")
-#     future.worker_nanny.restart()
+    if continuous:
+        cluster.start_cluster(nworkers)
+    else:
+        jobs = cluster.submit_jobs(nworkers)
+        if cluster_type == "local":
+            cluster.wait_for_jobs(jobs)


### PR DESCRIPTION
@scott-materials @laurenmm 

This is a first-attempt to keep a steady-state queue of workers for a slurm queue. You make a `submit.sh` file and then call this command in the same directory:
``` bash
simmate workflow-engine start-cluster 5 --continuous --type slurm
```
This means the cluster will maintain 5 slurm jobs at all times (running + pending). Whenever a job completes (i.e. a worker shuts down after hitting it's limit), then a new job will be submitted to replace it. If you just want to submit workers once and be done, you can remove the `--continuous` flag.

This will stop workers from hogging resources and let others' jobs get through the queue