### PR TITLE
Update frozen.py

### DIFF
--- a/src/simmate/apps/vasp/error_handlers/frozen.py
+++ b/src/simmate/apps/vasp/error_handlers/frozen.py
@@ -16,7 +16,7 @@ class Frozen(ErrorHandler):
 
     is_monitor = True
 
-    def __init__(self, timeout_limit: float = 3600):
+    def __init__(self, timeout_limit: float = 36000):
         self.timeout_limit = timeout_limit
 
     def check(self, directory: Path) -> bool:


### PR DESCRIPTION
Frozen error handler is triggered too quickly for HSE calcs. Proposed changing from 1 hr to 10 hrs