### PR TITLE
add timer to structure transformations ⏱️ 

### DIFF
--- a/src/simmate/apps/badelf/core/electride_finder.py
+++ b/src/simmate/apps/badelf/core/electride_finder.py
@@ -189,7 +189,7 @@ class ElectrideFinder:
         bader = elf_grid.run_pybader(threads)
 
         # Get the voxel indices for each found maxima
-        basin_maxima_vox_coords = elf_grid.get_vox_coords_from_frac_full_array(
+        basin_maxima_vox_coords = elf_grid.get_voxel_coords_from_frac_full_array(
             bader.bader_maxima_fractional
         ).astype(int)
         # Get the ELF values for the maxima
@@ -399,7 +399,7 @@ class ElectrideFinder:
                 # quadrant of the supercell
                 frac_coords = site.frac_coords
                 transformed_coords = transformations + frac_coords
-                voxel_coords = elf_grid.get_vox_coords_from_frac_full_array(
+                voxel_coords = elf_grid.get_voxel_coords_from_frac_full_array(
                     transformed_coords
                 ).astype(int)
                 # Get the feature label at each transformation. If the atom is not surrounded

--- a/src/simmate/apps/bader/toolkit/grid.py
+++ b/src/simmate/apps/bader/toolkit/grid.py
@@ -225,7 +225,7 @@ class Grid(VolumetricData):
     def interpolate_value_at_frac_coords(
         self, frac_coords, method: str = "linear"
     ) -> list[float]:
-        coords = self.get_vox_coords_from_frac_full_array(np.array(frac_coords))
+        coords = self.get_voxel_coords_from_frac_full_array(np.array(frac_coords))
         padded_data = np.pad(self.total, 10, mode="wrap")
 
         # interpolate grid to find values that lie between voxels. This is done

--- a/src/simmate/apps/evolution/models/chemical_system.py
+++ b/src/simmate/apps/evolution/models/chemical_system.py
@@ -63,13 +63,7 @@ class ChemicalSystemSearch(Calculation):
     @property
     def subworkflow(self):
         from simmate.workflows.utilities import get_workflow
-
-        if self.subworkflow_name == "relaxation.vasp.staged":
-            return get_workflow(self.subworkflow_name)
-        else:
-            raise Exception(
-                "Only `relaxation.vasp.staged` is supported in early testing"
-            )
+        return get_workflow(self.subworkflow_name)
 
     @property
     def individuals_datatable(self):

--- a/src/simmate/apps/evolution/models/chemical_system.py
+++ b/src/simmate/apps/evolution/models/chemical_system.py
@@ -63,6 +63,7 @@ class ChemicalSystemSearch(Calculation):
     @property
     def subworkflow(self):
         from simmate.workflows.utilities import get_workflow
+
         return get_workflow(self.subworkflow_name)
 
     @property

--- a/src/simmate/apps/evolution/models/fixed_composition.py
+++ b/src/simmate/apps/evolution/models/fixed_composition.py
@@ -870,7 +870,7 @@ class FitnessDistribution(PlotlyFigure):
         # Grab the calculation's structure and convert it to a dataframe
         structures_dataframe = search.individuals_completed.only(
             search.fitness_field
-        ).to_dataframe(search.fitness_field)
+        ).to_dataframe([search.fitness_field])
 
         # There's only one plot here, no subplot. So we make the scatter
         # object and just pass it directly to a Figure object

--- a/src/simmate/toolkit/transformations/base.py
+++ b/src/simmate/toolkit/transformations/base.py
@@ -144,7 +144,7 @@ class Transformation:
         structures,  # either a structure or list of structures. Depends on ninput.
         validators=[],
         max_attempts=10000,  # This will typically be greater than the time cutoff
-        max_time_per_atom=60,  # time in seconds transformation is allowed to try
+        max_time_per_atom=15,  # time in seconds transformation is allowed to try
     ):
         # Until we get a new valid structure (or run out of attempts), keep trying
         # with our given source. Assume we don't have a valid structure until

--- a/src/simmate/toolkit/transformations/base.py
+++ b/src/simmate/toolkit/transformations/base.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import time
 
 from simmate.toolkit import Structure
 
@@ -104,7 +105,6 @@ class Transformation:
         selector,
         datatable,
         select_kwargs: dict = {},
-        max_attempts: int = 100,
         **kwargs,  # for apply_transformation_with_validation
     ):
         logging.info(f"Creating a transformed structure with '{self.name}'")
@@ -123,24 +123,15 @@ class Transformation:
         # with our given source. Assume we don't have a valid structure until
         # proven otherwise
         new_structure = False
-        attempt = 0
-        while not new_structure and attempt <= max_attempts:
-            # add an attempt
-            attempt += 1
-
-            # make a new structure
-            new_structure = self.apply_transformation_with_validation(
-                parent_structures,
-                **kwargs,
-            )
+        # make a new structure
+        new_structure = self.apply_transformation_with_validation(
+            parent_structures,
+            **kwargs,
+        )
 
         # see if we got a structure or if we hit the max attempts and there's
         # a serious problem!
         if not new_structure:
-            logging.warning(
-                f"Failed to create a structure after {max_attempts} different"
-                "parent combinations. Giving up."
-            )
             return False
 
         # Otherwise we were successful
@@ -152,14 +143,23 @@ class Transformation:
         self,
         structures,  # either a structure or list of structures. Depends on ninput.
         validators=[],
-        max_attempts=100,
+        max_attempts=10000, # This will typically be greater than the time cutoff
+        max_time_per_atom=60, # time in seconds transformation is allowed to try
     ):
         # Until we get a new valid structure (or run out of attempts), keep trying
         # with our given source. Assume we don't have a valid structure until
         # proven otherwise
         new_structure = False
         attempt = 0
+        # our stop time depends on the number of atoms in the structure we're
+        # generating so we get a length here
+        num_atoms = len(structures[0]) if type(structures) == list else len(structures)
+        stop_time = time.time() + num_atoms*max_time_per_atom
+        
         while not new_structure and attempt <= max_attempts:
+            current_time = time.time()
+            if current_time >= stop_time:
+                break
             # add an attempt
             attempt += 1
 
@@ -186,12 +186,17 @@ class Transformation:
 
         # see if we got a structure or if we hit the max attempts and there's
         # a serious problem!
-        if not new_structure:
+        if not new_structure and attempt > max_attempts:
             logging.warning(
-                "Failed to create a structure from input after "
-                f"{max_attempts} attempts"
+                f"Failed to create a structure after {max_attempts} attempts."
+                "Giving up."
             )
             return False
-
+        elif not new_structure and current_time >= stop_time:
+            logging.warning(
+                f"Failed to create a structure after {num_atoms*max_time_per_atom} seconds."
+                "Giving up."
+            )
+            return False
         # return the structure and its parents
         return new_structure

--- a/src/simmate/toolkit/transformations/base.py
+++ b/src/simmate/toolkit/transformations/base.py
@@ -143,8 +143,8 @@ class Transformation:
         self,
         structures,  # either a structure or list of structures. Depends on ninput.
         validators=[],
-        max_attempts=10000, # This will typically be greater than the time cutoff
-        max_time_per_atom=60, # time in seconds transformation is allowed to try
+        max_attempts=10000,  # This will typically be greater than the time cutoff
+        max_time_per_atom=60,  # time in seconds transformation is allowed to try
     ):
         # Until we get a new valid structure (or run out of attempts), keep trying
         # with our given source. Assume we don't have a valid structure until
@@ -154,8 +154,8 @@ class Transformation:
         # our stop time depends on the number of atoms in the structure we're
         # generating so we get a length here
         num_atoms = len(structures[0]) if type(structures) == list else len(structures)
-        stop_time = time.time() + num_atoms*max_time_per_atom
-        
+        stop_time = time.time() + num_atoms * max_time_per_atom
+
         while not new_structure and attempt <= max_attempts:
             current_time = time.time()
             if current_time >= stop_time:


### PR DESCRIPTION
This is a quick fix for issue #716. It adds a timer to the transformation attempts so that transformations that are perpetually failing don't clog up workers for extended periods of time.